### PR TITLE
use inline nodepools

### DIFF
--- a/modules/google_gke/main.tf
+++ b/modules/google_gke/main.tf
@@ -1,5 +1,24 @@
 locals {
   master_ipv4_cidr_block = "172.16.0.32/28"
+  # convert k8s taint syntax into struct required by tf
+  # e.g.
+  #  "workload.sas.com/class:compute:NO_SCHEDULE"
+  #  into
+  # { "key" : "workload.sas.com/class",
+  #   "value" : "compute",
+  #   "effect" : "NO_SCHEDULE" }
+  #   ]
+  taint_effects = { NoSchedule = "NO_SCHEDULE"
+    PreferNoSchedule = "PREFER_NO_SCHEDULE"
+  NoExecute = "NO_EXECUTE" }
+  default_nodepool_taints = [
+    for taint in var.default_nodepool_taints : {
+      key    = split("=", split(":", taint)[0])[0]
+      value  = split("=", split(":", taint)[0])[1]
+      effect = local.taint_effects[split(":", taint)[1]]
+    }
+  ]
+  default_nodepool_autoscaling = var.default_nodepool_min_nodes == var.default_nodepool_max_nodes ? false : true
 }
 
 resource "google_container_cluster" "primary" {
@@ -16,11 +35,6 @@ resource "google_container_cluster" "primary" {
     channel = var.kubernetes_channel
   }
   min_master_version = var.kubernetes_version
-
-  # default node pool
-  # terraform recommends to create the default nodepool separately
-  remove_default_node_pool = true
-  initial_node_count       = 1
 
   master_authorized_networks_config {
     dynamic "cidr_blocks" {
@@ -51,18 +65,100 @@ resource "google_container_cluster" "primary" {
     cluster_ipv4_cidr_block = var.pod_cidr_block
   }
 
-}
+  initial_node_count       = var.default_nodepool_create ? 0 : 1
+  remove_default_node_pool = var.default_nodepool_create ? false : true
 
-resource "google_compute_firewall" "gke-ingress" {
-  name    = "${var.name}-gke-ingress"
-  network = var.network
-
-  source_ranges = [local.master_ipv4_cidr_block]
-
-  allow {
-    protocol = "tcp"
-    ports    = ["8443"]
+  dynamic "node_pool" {
+    for_each = var.default_nodepool_create ? [0] : []
+    content {
+      name = "default"
+      node_config {
+        preemptible     = false
+        machine_type    = var.default_nodepool_vm_type
+        disk_size_gb    = var.default_nodepool_os_disk_size
+        disk_type       = var.default_nodepool_os_disk_type
+        local_ssd_count = var.default_nodepool_local_ssd_count
+        labels          = merge(var.labels, var.default_nodepool_labels)
+        taint           = local.default_nodepool_taints
+        tags            = [var.name]
+        oauth_scopes = [
+          "https://www.googleapis.com/auth/logging.write",
+          "https://www.googleapis.com/auth/monitoring",
+          "https://www.googleapis.com/auth/devstorage.read_only",
+          "https://www.googleapis.com/auth/servicecontrol",
+          "https://www.googleapis.com/auth/service.management.readonly",
+          "https://www.googleapis.com/auth/trace.append"
+        ]
+      }
+      management {
+        auto_repair  = true
+        auto_upgrade = true
+      }
+      node_count         = local.default_nodepool_autoscaling ? null : var.default_nodepool_min_nodes
+      initial_node_count = local.default_nodepool_autoscaling ? var.default_nodepool_min_nodes : null
+      dynamic "autoscaling" {
+        for_each = local.default_nodepool_autoscaling ? [1] : []
+        content {
+          min_node_count = var.default_nodepool_min_nodes
+          max_node_count = var.default_nodepool_max_nodes
+        }
+      }
+    }
   }
+
+  dynamic "node_pool" {
+    for_each = var.node_pools
+    content {
+      name = node_pool.key
+      node_config {
+        preemptible     = false
+        machine_type    = node_pool.value["vm_type"]
+        disk_size_gb    = node_pool.value["os_disk_size"]
+        disk_type       = "pd-standard"
+        local_ssd_count = node_pool.value["local_ssd_count"]
+
+        labels = node_pool.value["node_labels"]
+        taint = [for taint in node_pool.value["node_taints"] : {
+          key    = split("=", split(":", taint)[0])[0]
+          value  = split("=", split(":", taint)[0])[1]
+          effect = local.taint_effects[split(":", taint)[1]]
+          }
+        ]
+        tags = [var.name]
+
+        oauth_scopes = [
+          "https://www.googleapis.com/auth/logging.write",
+          "https://www.googleapis.com/auth/monitoring",
+          "https://www.googleapis.com/auth/devstorage.read_only",
+          "https://www.googleapis.com/auth/servicecontrol",
+          "https://www.googleapis.com/auth/service.management.readonly",
+          "https://www.googleapis.com/auth/trace.append"
+        ]
+      }
+      management {
+        auto_repair  = true
+        auto_upgrade = true
+      }
+
+      node_count         = ((node_pool.value["min_nodes"] == node_pool.value["max_nodes"]) ? false : true) ? null : node_pool.value["min_nodes"]
+      initial_node_count = ((node_pool.value["min_nodes"] == node_pool.value["max_nodes"]) ? false : true) ? node_pool.value["min_nodes"] : null
+      dynamic "autoscaling" {
+        for_each = ((node_pool.value["min_nodes"] == node_pool.value["max_nodes"]) ? false : true) ? [1] : []
+        content {
+          min_node_count = node_pool.value["min_nodes"]
+          max_node_count = node_pool.value["max_nodes"]
+        }
+      }
+    }
+  }
+
+  #see https://github.com/hashicorp/terraform-provider-google/issues/6901
+  lifecycle {
+    ignore_changes = [
+      initial_node_count
+    ]
+  }
+
 
 }
 

--- a/modules/google_gke/variables.tf
+++ b/modules/google_gke/variables.tf
@@ -7,3 +7,47 @@ variable "network" {}
 variable "subnet" {}
 variable "endpoint_access" {}
 variable "pod_cidr_block" {}
+
+variable "default_nodepool_vm_type" {
+  default = "e2-medium"
+}
+
+variable "default_nodepool_node_count" {
+  default = 3
+}
+
+variable "default_nodepool_max_nodes" {
+  default = 10
+}
+
+variable "default_nodepool_min_nodes" {
+  default = 1
+}
+
+variable "default_nodepool_taints" {
+  type    = list
+  default = []
+}
+
+variable "default_nodepool_labels" {
+  type    = map
+  default = {}
+}
+
+variable "default_nodepool_local_ssd_count" {
+  default = 0
+}
+variable "default_nodepool_os_disk_size" {
+  default = 100
+}
+
+variable "default_nodepool_os_disk_type" {
+  default = "pd-standard"
+}
+
+variable "default_nodepool_create" {
+  default = false
+}
+
+variable "node_pools" {
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -59,10 +59,10 @@ output "provider" {
 
 
 output "ssh_private_key" {
-    value = var.ssh_public_key == "" ? element(coalescelist(data.tls_public_key.public_key.*.private_key_pem, [""]), 0): null
+  value = var.ssh_public_key == "" ? element(coalescelist(data.tls_public_key.public_key.*.private_key_pem, [""]), 0) : null
 }
 output "ssh_public_key" {
-    value = var.ssh_public_key == "" ? element(coalescelist(data.tls_public_key.public_key.*.public_key_pem, [""]), 0): null
+  value = var.ssh_public_key == "" ? element(coalescelist(data.tls_public_key.public_key.*.public_key_pem, [""]), 0) : null
 }
 
 

--- a/variables.tf
+++ b/variables.tf
@@ -253,3 +253,6 @@ variable "postgres_ssl_enforcement_enabled" {
   default     = true
 }
 
+variable "nodepools_inline" {
+  default = true
+}


### PR DESCRIPTION
- speeds up initial creation considerably
- downside: any change to a nodepool will recreate the cluster
- changes are wrapped in undocumented nodepools_inline boolean variables