### PR TITLE
Updated Jump/NFS Server OS to 20.04 resolving google-guest-agent issue

### DIFF
--- a/modules/google_vm/variables.tf
+++ b/modules/google_vm/variables.tf
@@ -51,7 +51,7 @@ variable "ssh_public_key" {
 }
 
 variable "os_image" {
-  default = "ubuntu-os-cloud/ubuntu-1804-lts" # FAMILY/PROJECT glcoud compute images list
+  default = "ubuntu-os-cloud/ubuntu-2004-lts" # FAMILY/PROJECT glcoud compute images list
 }
 
 

--- a/vm.tf
+++ b/vm.tf
@@ -34,7 +34,7 @@ module "nfs_server" {
   tags             = var.tags
 
   subnet           = local.subnet_names["misc"] // Name or self_link to subnet
-  os_image         = "ubuntu-os-cloud/ubuntu-1804-lts"
+  os_image         = "ubuntu-os-cloud/ubuntu-2004-lts"
 
   vm_admin         = var.nfs_vm_admin
   ssh_public_key   = local.ssh_public_key
@@ -60,7 +60,7 @@ module "jump_server" {
   tags             = var.tags
 
   subnet           = local.subnet_names["misc"] // Name or self_link to subnet
-  os_image         = "ubuntu-os-cloud/ubuntu-1804-lts"
+  os_image         = "ubuntu-os-cloud/ubuntu-2004-lts"
 
   vm_admin         = var.jump_vm_admin
   ssh_public_key   = local.ssh_public_key


### PR DESCRIPTION
Closes #89 - Updating the OS resolves the `googe-guest-agent` package issue.