### PR TITLE
network outputs for auto / byo now fixed

### DIFF
--- a/modules/network/outputs.tf
+++ b/modules/network/outputs.tf
@@ -8,7 +8,7 @@ output "network_self_link" {
 
 output subnets {
   value = {
-    gke : var.create_subnets ? element(coalescelist(google_compute_subnetwork.gke_subnet,[]),0) : data.google_compute_subnetwork.gke_subnet.0
-    misc: var.create_subnets ? element(coalescelist(google_compute_subnetwork.misc_subnet,[]),0) : data.google_compute_subnetwork.misc_subnet.0
+    gke  : var.create_subnets ? google_compute_subnetwork.gke_subnet.0  : data.google_compute_subnetwork.gke_subnet.0
+    misc : var.create_subnets ? google_compute_subnetwork.misc_subnet.0 : data.google_compute_subnetwork.misc_subnet.0
   }
 }


### PR DESCRIPTION
Closes #87 - Output logic now works for both the automatic and byo networking when one applies and destroys their cluster.