### PR TITLE
Filestore tier/size parameters (#63)

### DIFF
--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -224,7 +224,7 @@ stateful = {
 | Name | Description | Type | Default | Notes |
 | :--- | ---: | ---: | ---: | ---: |
 | filestore_tier | The service tier for the Google Filestore Instance | string | "BASIC_HDD" | Valid Values: "BASIC_HDD", "BASIC_SSD" (previously called "STANDARD" and "PREMIUM" respectively.)  |
-| filestore_size_in_gb | Size in GB of Filesystem in the Google Filestore Instance | number | 2560 | 2560 GB is the minimum size for the BASIC_SSD tier. The BASIC_HDD tier allows a minum size of 1024 GB. |
+| filestore_size_in_gb | Size in GB of Filesystem in the Google Filestore Instance | number | 1024 for BASIC_HDD, 2560 for BASIC_SDD | 2560 GB is the minimum size for the BASIC_SSD tier. The BASIC_HDD tier allows a minimum size of 1024 GB. |
 
 
 ## Postgres

--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -219,6 +219,14 @@ stateful = {
 | nfs_vm_admin | OS Admin User for the NFS server VM | string | "nfsuser" | The NFS server VM is only created when storage_type="standard" |
 | nfs_raid_disk_size | Size in Gb for each disk of the RAID5 cluster on the NFS server VM | number | 128 | The NFS server VM is only created when storage_type="standard" |
 
+### For `storage_type=ha` only (Google Filestore)
+
+| Name | Description | Type | Default | Notes |
+| :--- | ---: | ---: | ---: | ---: |
+| filestore_tier | The service tier for the Google Filestore Instance | string | "BASIC_HDD" | Valid Values: "BASIC_HDD", "BASIC_SSD" (previously called "STANDARD" and "PREMIUM" respectively.)  |
+| filestore_size_in_gb | Size in GB of Filesystem in the Google Filestore Instance | number | 2560 | 2560 GB is the minimum size for the BASIC_SSD tier. The BASIC_HDD tier allows a minum size of 1024 GB. |
+
+
 ## Postgres
 
 | Name | Description | Type | Default | Notes |

--- a/main.tf
+++ b/main.tf
@@ -124,7 +124,7 @@ EOT
 resource "google_filestore_instance" "rwx" {
   name   = "${var.prefix}-rwx-filestore"
   count  = var.storage_type == "ha" ? 1 : 0 
-  tier   = var.filestore_tier
+  tier   = upper(var.filestore_tier)
   zone   = local.zone
   labels = var.tags
 

--- a/main.tf
+++ b/main.tf
@@ -91,6 +91,12 @@ locals {
   gke_pod_range_index = length(var.subnet_names) == 0 ? index(module.vpc.subnets["gke"].secondary_ip_range.*.range_name, local.subnet_names["gke_pods_range_name"]) : 0
   gke_pod_subnet_cidr = length(var.subnet_names) == 0 ? var.gke_pod_subnet_cidr : module.vpc.subnets["gke"].secondary_ip_range[local.gke_pod_range_index].ip_cidr_range
 
+  filestore_size_in_gb = (
+    var.filestore_size_in_gb == null
+      ? ( contains(["BASIC_HDD","STANDARD"], upper(var.filestore_tier)) ? 1024 : 2560 )
+      : var.filestore_size_in_gb
+  )
+
 }
 
 data "external" "git_hash" {
@@ -129,7 +135,7 @@ resource "google_filestore_instance" "rwx" {
   labels = var.tags
 
   file_shares {
-    capacity_gb = var.filestore_size_in_gb
+    capacity_gb = local.filestore_size_in_gb
     name        = "volumes"
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -360,7 +360,7 @@ variable "postgres_database_flags" {
 
 ## filstore
 variable filestore_size_in_gb {
-  default = 2560
+  default = null
 }
 
 variable filestore_tier {

--- a/variables.tf
+++ b/variables.tf
@@ -49,7 +49,7 @@ variable "kubernetes_version" {
 
   validation {
     condition     = (can(regex("^\\d.\\d+.\\d+-gke.\\d+$", var.kubernetes_version)) || var.kubernetes_version == "latest")
-    error_message = "The format for kuberentes version is: x.yy-gke.zzzz or 'latest'."
+    error_message = "The format for kubernetes version is: x.yy-gke.zzzz or 'latest'."
   }
 }
 
@@ -360,11 +360,17 @@ variable "postgres_database_flags" {
 
 ## filstore
 variable filestore_size_in_gb {
-  default = 1024
+  default = 2560
 }
 
 variable filestore_tier {
-  default = "STANDARD"
+  default = "BASIC_HDD"
+  type = string
+  validation {
+      # we allow the old values "STANDARD" and "PREMIUM" but do not document them
+      condition     = (contains(["STANDARD", "PREMIUM", "BASIC_HDD", "BASIC_SSD"], upper(var.filestore_tier)))
+      error_message = "Filestore tier must be one of BASIC_HDD, BASIC_SSD."
+    }
 }
 
 variable "create_container_registry" {


### PR DESCRIPTION
- use new V1 names (BASIC_HDD, BASIC_SSD)
- support old names (STANDARD, PREMIUM), but do not document
- increase default size to minimum required by BASIC_SSD (2T)
- do not support HIGH_SCALE_SSD since it is still Beta