### PR TITLE
(IAC-396) Update kubectl to 1.21.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG GCP_CLI_VERSION=342.0.0
 FROM hashicorp/terraform:$TERRAFORM_VERSION as terraform
 
 FROM google/cloud-sdk:$GCP_CLI_VERSION
-ARG KUBECTL_VERSION=1.21.6
+ARG KUBECTL_VERSION=1.21.7
 
 WORKDIR /viya4-iac-gcp
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Operational knowledge of
 - Terraform or Docker
   - #### Terraform
     - [Terraform](https://www.terraform.io/downloads.html) - v1.0.0
-    - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl) - v1.21.6
+    - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl) - v1.21.7
     - [jq](https://stedolan.github.io/jq/) - v1.6
     - [gcloud CLI](https://cloud.google.com/sdk/gcloud) - (optional - useful as an alternative to the Google Cloud Platform Portal) - v342.0.0
   - #### Docker


### PR DESCRIPTION
Update the default kubectl version in the Dockerfile and the README to 1.21.7