### PR TITLE
(IAC-404) Migrate to the cos_containerd Node Pool Image

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -139,7 +139,7 @@ module "gke" {
       auto_upgrade       = (var.kubernetes_channel == "UNSPECIFIED") ? false : true
       preemptible        = false
       disk_type          = "pd-standard"
-      image_type         = "COS"
+      image_type         = "cos_containerd"
       accelerator_count  = settings.accelerator_count
       accelerator_type   = settings.accelerator_type
       initial_node_count = settings.initial_node_count

--- a/main.tf
+++ b/main.tf
@@ -139,7 +139,7 @@ module "gke" {
       auto_upgrade       = (var.kubernetes_channel == "UNSPECIFIED") ? false : true
       preemptible        = false
       disk_type          = "pd-standard"
-      image_type         = "cos_containerd"
+      image_type         = "COS_CONTAINERD"
       accelerator_count  = settings.accelerator_count
       accelerator_type   = settings.accelerator_type
       initial_node_count = settings.initial_node_count


### PR DESCRIPTION
Migrates to the cos_containerd node pool image so that the nodes will now use the containerd container runtime.
https://cloud.google.com/kubernetes-engine/docs/concepts/using-containerd#migrating

This change is also taking place since the Docker container runtime will no longer be supported by Kubernetes in the upcoming v1.24 release.
https://kubernetes.io/blog/2022/01/07/kubernetes-is-moving-on-from-dockershim/

Tests:
Was able to create both a v1.22.3-gke.1500  & v1.21.6-gke.1500 with the cos_containerd node pool image and perform a successful Viya/Monitoring/Logging deployment on them.

