### PR TITLE
(IAC-465) Update the default K8s version in the examples tfvars

### DIFF
--- a/examples/sample-input-byo.tfvars
+++ b/examples/sample-input-byo.tfvars
@@ -37,7 +37,7 @@ postgres_servers = {
 }
 
 # GKE config
-kubernetes_version = "1.21.6-gke.1500"
+kubernetes_version = "1.21.6-gke.1503"
 default_nodepool_min_nodes = 2
 default_nodepool_vm_type    = "e2-standard-8"
 

--- a/examples/sample-input-ha.tfvars
+++ b/examples/sample-input-ha.tfvars
@@ -27,7 +27,7 @@ postgres_servers = {
 }
 
 # GKE config
-kubernetes_version = "1.21.6-gke.1500"
+kubernetes_version = "1.21.6-gke.1503"
 default_nodepool_min_nodes = 2
 default_nodepool_vm_type    = "e2-standard-8"
 

--- a/examples/sample-input-minimal.tfvars
+++ b/examples/sample-input-minimal.tfvars
@@ -27,7 +27,7 @@ tags = {} # e.g., { "key1" = "value1", "key2" = "value2" }
 # }
 
 # GKE config
-kubernetes_version = "1.21.6-gke.1500"
+kubernetes_version = "1.21.6-gke.1503"
 default_nodepool_min_nodes = 1
 default_nodepool_vm_type   = "n2-standard-2"
 

--- a/examples/sample-input.tfvars
+++ b/examples/sample-input.tfvars
@@ -27,7 +27,7 @@ postgres_servers = {
 }
 
 # GKE config
-kubernetes_version = "1.21.6-gke.1500"
+kubernetes_version = "1.21.6-gke.1503"
 default_nodepool_min_nodes = 2
 default_nodepool_vm_type    = "e2-standard-8"
 


### PR DESCRIPTION
Update the example versions to 1.21.6-gke.1503, the old version has been removed by Google.

https://cloud.google.com/kubernetes-engine/docs/release-notes-regular#2022-r03_version_updates

Test:

- Was able to create a 1.21.6-gke.1503 cluster with the sample template and perform a successful deployment on it.