### PR TITLE
(IAC-531) added git share directive for viya4-iac-gcp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get install -y jq \
   && chmod 755 ./kubectl /viya4-iac-gcp/docker-entrypoint.sh \
   && mv ./kubectl /usr/local/bin/kubectl \
   && chmod g=u -R /etc/passwd /etc/group /viya4-iac-gcp \
+  && git config --global --add safe.directory /viya4-iac-gcp \
   && terraform init
 
 ENV TF_VAR_iac_tooling=docker


### PR DESCRIPTION
Fixes this issue : https://github.blog/2022-04-12-git-security-vulnerability-announced/