### PR TITLE
(IAC-542) Update kubectl and default K8s version to 1.22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG GCP_CLI_VERSION=342.0.0
 FROM hashicorp/terraform:$TERRAFORM_VERSION as terraform
 
 FROM google/cloud-sdk:$GCP_CLI_VERSION
-ARG KUBECTL_VERSION=1.21.7
+ARG KUBECTL_VERSION=1.22.10
 
 WORKDIR /viya4-iac-gcp
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Operational knowledge of
 - Terraform or Docker
   - #### Terraform
     - [Terraform](https://www.terraform.io/downloads.html) - v1.0.0
-    - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl) - v1.21.7
+    - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl) - v1.22.10
     - [jq](https://stedolan.github.io/jq/) - v1.6
     - [gcloud CLI](https://cloud.google.com/sdk/gcloud) - (optional - useful as an alternative to the Google Cloud Platform Portal) - v342.0.0
   - #### Docker

--- a/examples/sample-input-byo.tfvars
+++ b/examples/sample-input-byo.tfvars
@@ -37,7 +37,7 @@ postgres_servers = {
 }
 
 # GKE config
-kubernetes_version = "1.21.6-gke.1503"
+kubernetes_version = "1.22.9-gke.1500"
 default_nodepool_min_nodes = 2
 default_nodepool_vm_type    = "e2-standard-8"
 

--- a/examples/sample-input-connect.tfvars
+++ b/examples/sample-input-connect.tfvars
@@ -27,7 +27,7 @@ postgres_servers = {
 }
 
 # GKE config
-kubernetes_version = "1.21.6-gke.1503"
+kubernetes_version = "1.22.9-gke.1500"
 default_nodepool_min_nodes = 2
 default_nodepool_vm_type    = "e2-standard-8"
 

--- a/examples/sample-input-ha.tfvars
+++ b/examples/sample-input-ha.tfvars
@@ -27,7 +27,7 @@ postgres_servers = {
 }
 
 # GKE config
-kubernetes_version = "1.21.6-gke.1503"
+kubernetes_version = "1.22.9-gke.1500"
 default_nodepool_min_nodes = 2
 default_nodepool_vm_type    = "e2-standard-8"
 

--- a/examples/sample-input-minimal.tfvars
+++ b/examples/sample-input-minimal.tfvars
@@ -27,7 +27,7 @@ tags = {} # e.g., { "key1" = "value1", "key2" = "value2" }
 # }
 
 # GKE config
-kubernetes_version = "1.21.6-gke.1503"
+kubernetes_version = "1.23.6-gke.1700"
 default_nodepool_min_nodes = 1
 default_nodepool_vm_type   = "n2-standard-2"
 

--- a/examples/sample-input-minimal.tfvars
+++ b/examples/sample-input-minimal.tfvars
@@ -27,7 +27,7 @@ tags = {} # e.g., { "key1" = "value1", "key2" = "value2" }
 # }
 
 # GKE config
-kubernetes_version = "1.23.6-gke.1700"
+kubernetes_version = "1.22.9-gke.1500"
 default_nodepool_min_nodes = 1
 default_nodepool_vm_type   = "n2-standard-2"
 

--- a/examples/sample-input.tfvars
+++ b/examples/sample-input.tfvars
@@ -27,7 +27,7 @@ postgres_servers = {
 }
 
 # GKE config
-kubernetes_version = "1.21.6-gke.1503"
+kubernetes_version = "1.22.9-gke.1500"
 default_nodepool_min_nodes = 2
 default_nodepool_vm_type    = "e2-standard-8"
 


### PR DESCRIPTION
## Changes

Since Viya will be supporting 1.21, 1.22, and 1.23 in June, the kubectl version is being changed to 1.22 so that it's within the +/- 1 range of the supported versions. The default version in the example .tfvars is also being changed to 1.22.9-gke.1500 so that it is also in the middle of the support version range. 

## Tests

Test summary, more detail is present in the internal ticket.

| Cloud Provider | kubectl version | K8s Version      | Cadence   | Ingress-nginx version | Deployment Stabilized |
|----------------|-----------------|------------------|-----------|-----------------------|-----------------------|
| GCP            | 1.22.10         | 1.22.9-gke.1500  | Fast:2020 | v1.1.1                | Yes                   |
| GCP            | 1.22.10         | 1.22.9-gke.1500  | 2022.1.1  | v1.1.1                | Yes                   |
| GCP            | 1.22.10         | 1.23.6-gke.1700  | Fast:2020 | v1.1.1                | Yes                   |
| GCP            | 1.22.10         | 1.21.11-gke.1100 | 2021.2    | v0.50.0               | Yes                   |

