### PR TITLE
feat: (IAC-654) GKE add support for K8s 1.24

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG GCP_CLI_VERSION=342.0.0
 FROM hashicorp/terraform:$TERRAFORM_VERSION as terraform
 
 FROM google/cloud-sdk:$GCP_CLI_VERSION
-ARG KUBECTL_VERSION=1.22.10
+ARG KUBECTL_VERSION=1.23.8
 
 WORKDIR /viya4-iac-gcp
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Operational knowledge of
 - Terraform or Docker
   - #### Terraform
     - [Terraform](https://www.terraform.io/downloads.html) - v1.0.0
-    - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl) - v1.22.10
+    - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl) - v1.23.8
     - [jq](https://stedolan.github.io/jq/) - v1.6
     - [gcloud CLI](https://cloud.google.com/sdk/gcloud) - (optional - useful as an alternative to the Google Cloud Platform Portal) - v342.0.0
   - #### Docker

--- a/examples/sample-input-byo.tfvars
+++ b/examples/sample-input-byo.tfvars
@@ -37,7 +37,7 @@ postgres_servers = {
 }
 
 # GKE config
-kubernetes_version = "1.22.9-gke.1500"
+kubernetes_version = "1.23.8-gke.1900"
 default_nodepool_min_nodes = 2
 default_nodepool_vm_type    = "e2-standard-8"
 

--- a/examples/sample-input-connect.tfvars
+++ b/examples/sample-input-connect.tfvars
@@ -27,7 +27,7 @@ postgres_servers = {
 }
 
 # GKE config
-kubernetes_version = "1.22.9-gke.1500"
+kubernetes_version = "1.23.8-gke.1900"
 default_nodepool_min_nodes = 2
 default_nodepool_vm_type    = "e2-standard-8"
 

--- a/examples/sample-input-ha.tfvars
+++ b/examples/sample-input-ha.tfvars
@@ -27,7 +27,7 @@ postgres_servers = {
 }
 
 # GKE config
-kubernetes_version = "1.22.9-gke.1500"
+kubernetes_version = "1.23.8-gke.1900"
 default_nodepool_min_nodes = 2
 default_nodepool_vm_type    = "e2-standard-8"
 

--- a/examples/sample-input-minimal.tfvars
+++ b/examples/sample-input-minimal.tfvars
@@ -27,7 +27,7 @@ tags = {} # e.g., { "key1" = "value1", "key2" = "value2" }
 # }
 
 # GKE config
-kubernetes_version = "1.22.9-gke.1500"
+kubernetes_version = "1.23.8-gke.1900"
 default_nodepool_min_nodes = 1
 default_nodepool_vm_type   = "n2-standard-2"
 

--- a/examples/sample-input.tfvars
+++ b/examples/sample-input.tfvars
@@ -27,7 +27,7 @@ postgres_servers = {
 }
 
 # GKE config
-kubernetes_version = "1.22.9-gke.1500"
+kubernetes_version = "1.23.8-gke.1900"
 default_nodepool_min_nodes = 2
 default_nodepool_vm_type    = "e2-standard-8"
 

--- a/main.tf
+++ b/main.tf
@@ -17,7 +17,6 @@ provider "kubernetes" {
   host                   = "https://${module.gke.endpoint}"
   cluster_ca_certificate = base64decode(module.gke.ca_certificate)
   token                  = data.google_client_config.current.access_token
-  load_config_file       = false
 }
 
 data "google_client_config" "current" {}
@@ -81,7 +80,7 @@ data "google_container_engine_versions" "gke-version" {
 
 module "gke" {
   source                        = "terraform-google-modules/kubernetes-engine/google//modules/private-cluster"
-  version                       = "14.3.0"
+  version                       = "15.0.2"
   project_id                    = var.project
   name                          = "${var.prefix}-gke"
   region                        = local.region

--- a/modules/kubeconfig/main.tf
+++ b/modules/kubeconfig/main.tf
@@ -49,7 +49,7 @@ resource "kubernetes_secret" "sa_secret" {
 data "kubernetes_secret" "sa_secret" {
   count = var.create_static_kubeconfig ? 1 : 0
   metadata {
-    name = "${kubernetes_secret.sa_secret[0].metadata.0.name}"
+    name = kubernetes_secret.sa_secret[0].metadata[0].name
     namespace = var.namespace
   }
 }

--- a/modules/kubeconfig/main.tf
+++ b/modules/kubeconfig/main.tf
@@ -29,6 +29,9 @@ data "template_file" "kubeconfig_sa" {
     token        = lookup(kubernetes_secret.sa_secret.0.data,"token", "")
     namespace    = var.namespace
   }
+  depends_on = [
+    kubernetes_secret.sa_secret
+  ]
 }
 
 # 1.24 change: Create service account secret

--- a/modules/kubeconfig/main.tf
+++ b/modules/kubeconfig/main.tf
@@ -20,7 +20,7 @@ data "template_file" "kubeconfig_provider" {
 data "kubernetes_secret" "sa_secret" {
   count = var.create_static_kubeconfig ? 1 : 0
   metadata {
-    name      = kubernetes_service_account.kubernetes_sa.0.default_secret_name
+    name      = kubernetes_secret.sa_secret.0.metadata.0.name
     namespace = var.namespace
   }
   depends_on = [kubernetes_secret.sa_secret]

--- a/variables.tf
+++ b/variables.tf
@@ -36,7 +36,7 @@ variable "iac_tooling" {
   default     = "terraform"
 }
 
-## Channel - UNSPECIFIED/STABLE/REGULAR/RAPID - RAPID is currently the only channel that supports k8s v1.18
+## Channel - UNSPECIFIED/STABLE/REGULAR/RAPID
 variable "kubernetes_channel" {
   default = "UNSPECIFIED"
 }

--- a/versions.tf
+++ b/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     kubernetes  = {
       source  = "hashicorp/kubernetes"
-      version = "2.13.0"
+      version = "2.13.0" # Constrained by Google
     }
     local       = {
       source  = "hashicorp/local"

--- a/versions.tf
+++ b/versions.tf
@@ -12,12 +12,12 @@ terraform {
     }
     kubernetes  = {
       source  = "hashicorp/kubernetes"
-      version = "1.13.0" # Constrained by Google
+      version = "2.13.0"
     }
     local       = {
       source  = "hashicorp/local"
       version = "2.1.0"
-    }
+    }F
     template    = {
       source  = "hashicorp/template"
       version = "2.2.0"

--- a/versions.tf
+++ b/versions.tf
@@ -17,7 +17,7 @@ terraform {
     local       = {
       source  = "hashicorp/local"
       version = "2.1.0"
-    }F
+    }
     template    = {
       source  = "hashicorp/template"
       version = "2.2.0"


### PR DESCRIPTION
## Background:
Starting from Kubernetes version `1.24.0` service account token is not automatically generated, thus it has to be created separately. The following resources were updated by the provider `hashicorp/kubernetes` to handle this change in `v2.13.0`: `d/kubernetes_service_account`, `r/kubernetes_default_service_account`, `r/kubernetes_service_account`. For Kubernetes clusters running v1.24+ `default_secret_name` will be empty. A warning message will be printed once any of the above resources are in use. 

## Changes
* To support 1.24+ Kubernetes version in GKE, a secret is manually created for the service account
* The default K8s value is updated from 1.22.9-gke.1500 to 1.23.8-gke.1900
* The default kubectl value is updated from 1.22.10 to 1.23.8
* The `terraform-google-modules/kubernetes-engine/google//modules/private-cluster` had to be updated to 15.0.2, since its version constraint allows support for `hashicorp/kubernetes` version ~> 2.0. The older 14.3.0 did not allow it.
  * Note: I specifically chose version 15.0.2 not something and newer since it it introduces a very little change to the module, on our end we don't have to do too many code updates.
  * I went through the module's changelog to ensure no other changes were needed in the code base https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/blob/v15.0.2/CHANGELOG.md
  * In the future we will be doing a general update where we update the modules/providers to the newest working version.
* Updated `hashicorp/kubernetes` to 2.13.0
  * Removed `load_config_file` from the provider parameters, that feature was deprecated in `hashicorp/kubernetes` v2 and we were setting that value to false anyways so that behavior was not being used.

## Tests

More details and artifacst in interal tickets

Peformed the following
1. Created a v1.24.2-gke.1900 cluster with the updated code and successfully deployed Viya
1. Created a v1.23.8-gke.1900 cluster with the updated code and successfully deployed Viya
1. Created a v1.22.11-gke.400 cluster with the updated code and successfully deployed Viya
1. Created a v1.24.2-gke.1900 cluster with `create_static_kubeconfig=false` and verifed that the code workflow to create a provider based kube config was not modifed. I was able to use the provider based kube config to view cluster resources.