### PR TITLE
docs: (IAC-654) Update default value for create_static_kubeconfig

### DIFF
--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -101,7 +101,7 @@ The application of a Kubernetes version in GCP has some limitations when assigni
 | enable_cluster_autoscaling | Enable cluster autoscaling | bool | false | |
 | cluster_autoscaling_max_cpu_cores | MAX number of cores in the cluster | number | 500 | |
 | cluster_autoscaling_max_memory_gb | MAX number of gb of memory in the cluster | number | 10000 | |
-| create_static_kubeconfig | Allows the user to create a provider / service account based kube config file | bool | false | A value of `false` will default to using the cloud providers mechanism for generating the kubeconfig file. A value of `true` will create a static kubeconfig which utilizes a `Service Account` and `Cluster Role Binding` to provide credentials. |
+| create_static_kubeconfig | Allows the user to create a provider / service account based kube config file | bool | true | A value of `false` will default to using the cloud providers mechanism for generating the kubeconfig file. A value of `true` will create a static kubeconfig which utilizes a `Service Account` and `Cluster Role Binding` to provide credentials. |
 | regional | Create a regional GKE control plane | bool | true | If false a zonal GKE control plane is created |
 | create_jump_vm | Create bastion host | bool | true | |
 | create_jump_public_ip | Add public ip to jump VM | bool | true | |


### PR DESCRIPTION
### Changes
Update the default value for `create_static_kubeconfig` in the docs/CONFIG-VARS.md documentation.