### PR TITLE
feat: (IAC-705) Update default PostgreSQL server_version to 13

### DIFF
--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -259,7 +259,7 @@ Each server element, like `foo = {}`, can contain none, some, or all of the para
 | backup_count | The number of automated backups to retain, from 1 to 365 | string | "7" | Take note this is a **COUNT** not number of days |
 | administrator_login | The Administrator Login for the PostgreSQL Server. Changing this forces a new resource to be created. | string | "pgadmin" | | |
 | administrator_password | The Password associated with the administrator_login for the PostgreSQL Server | string | "my$up3rS3cretPassw0rd" |  |
-| server_version | The version of the  PostgreSQL server instance | string | "11" | Supported values are 11 and 12 |
+| server_version | The version of the  PostgreSQL server instance | string | "13" | Supported values are 11-14 |
 | ssl_enforcement_enabled | Enforce SSL on connection to the PostgreSQL database | bool | true | |
 | availability_type | The availability type for the master instance. | string | "ZONAL" | This is only used to set up high availability for the PostgreSQL instance. Can be either `ZONAL` or `REGIONAL`. |
 | database_flags | Database flags for the master instance. | list(object({})) |  | More details can be found [here](https://cloud.google.com/sql/docs/postgres/flags) |
@@ -281,7 +281,7 @@ postgres_servers = {
     backup_count                           = 7 # Number of backups to retain, not in days
     administrator_login                    = "pgadmin"
     administrator_password                 = "my$up3rS3cretPassw0rd"
-    server_version                         = "11"
+    server_version                         = "13"
     availability_type                      = "ZONAL"
     ssl_enforcement_enabled                = true
     database_flags                         = [{ name = "foo" value = "true"}, { name = "bar", value = "false"}]

--- a/variables.tf
+++ b/variables.tf
@@ -288,7 +288,7 @@ variable "postgres_server_defaults" {
     backup_count                           = "7" # Number of backups to retain, not days
     administrator_login                    = "pgadmin"
     administrator_password                 = "my$up3rS3cretPassw0rd"
-    server_version                         = "11"
+    server_version                         = "13"
     availability_type                      = "ZONAL"
     ssl_enforcement_enabled                = true
     database_flags                         = []


### PR DESCRIPTION
### Changes

Changes the default value for  the `server_version` variable which is contained within the `postgres_server_defaults` map to 13.
The user can select any version between 11-14 to suite their SAS Viya deployment requirements.

### Tests

Ran through the following deployment scenarios to test out PG

| Scenario | Provider | K8s Version | PG Version | Order | Cadence | Deployment Stabilized | Notes |
|---|---|---|---|---|---|---|---|
| PostgreSQL V11 | GCP | v1.23.8-gke.1900 | 11.16 | * | Fast:2020 | Yes |  |
| PostgreSQL V12 | GCP | v1.23.8-gke.1900 | 12.11 | * | Fast:2020 | Yes |  |
| PostgreSQL V13 | GCP | v1.23.8-gke.1900 | 13.7 | *| Fast:2020 | Yes | New default, did not define server_version in .tfvars |
| PostgreSQL V14 | GCP | v1.23.8-gke.1900 | 14.4 | *| Fast:2020 | Yes |  |
