### PR TITLE
fix: (IAC-476) Change Filestore location param value

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -57,7 +57,7 @@ resource "google_filestore_instance" "rwx" {
   name   = "${var.prefix}-rwx-filestore"
   count  = var.storage_type == "ha" ? 1 : 0 
   tier   = upper(var.filestore_tier)
-  location   = local.location
+  location   = local.zone
   labels = var.tags
 
   file_shares {


### PR DESCRIPTION
### Changes
The `google_filestore_instance` resource `location` parameter needs to be a zone value
See https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/filestore_instance

### Tests
In my tfvars I set my location to "location", the code locals.tf successfully selected the first zone from that location and local.zone was successfully used for the filestore resource.  