### PR TITLE
feat: (IAC-193) Add base max_connections and max_prepared_transactions values

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -88,6 +88,7 @@ locals {
 
   # PostgreSQL
   postgres_servers = var.postgres_servers == null ? {} : { for k, v in var.postgres_servers : k => merge( var.postgres_server_defaults, v, )}
+  base_database_flags = [{ name = "max_prepared_transactions", value = "1024" }, { name = "max_connections", value = "1024" }]
 
   postgres_outputs = length(module.postgresql) != 0 ? { for k,v in module.postgresql :
     k => {

--- a/main.tf
+++ b/main.tf
@@ -221,7 +221,7 @@ module "postgresql" {
   user_labels                      = var.tags
 
   database_version                 = "POSTGRES_${each.value.server_version}"
-  database_flags                   = each.value.database_flags
+  database_flags                   = values(zipmap(concat(local.base_database_flags.*.name,each.value.database_flags.*.name),concat(local.base_database_flags,each.value.database_flags)))
 
   backup_configuration = {
     enabled                        = each.value.backups_enabled


### PR DESCRIPTION
### Changes

Made a change so that the default `max_prepared_transactions` & `max_connections` is set to 1024 for each Postgres server as recommended by the Viya deployment guide. The user is still able to override these values themselves with the existing `database_flags` parameter. 


### Tests

Ran through the following scenarios.

See internal ticket for artifacts/additional details

1. Check default settings are applied `[{ name = "max_prepared_transactions", value = "1024" }, { name = "max_connections", value = "1024" }]` and Viya was successfully deployed
2. Verified the user can override the `database_flags` with their own values and it correct merges with the `base_database_flags`
3. Update `max_connections` in .tfvars and reapply, GCP automatically restarts the DB server and the new value is applied correctly.
4. Verified the that multiple DB instances each have their own configurable `database_flags` values.
