### PR TITLE
feat: (IAC-822) Update kubernetes_version to 1.23.14-gke.401 in tfvars

### DIFF
--- a/examples/sample-input-byo.tfvars
+++ b/examples/sample-input-byo.tfvars
@@ -37,7 +37,7 @@ postgres_servers = {
 }
 
 # GKE config
-kubernetes_version = "1.23.8-gke.1900"
+kubernetes_version = "1.23.14-gke.401"
 default_nodepool_min_nodes = 2
 default_nodepool_vm_type    = "e2-standard-8"
 

--- a/examples/sample-input-connect.tfvars
+++ b/examples/sample-input-connect.tfvars
@@ -27,7 +27,7 @@ postgres_servers = {
 }
 
 # GKE config
-kubernetes_version = "1.23.8-gke.1900"
+kubernetes_version = "1.23.14-gke.401"
 default_nodepool_min_nodes = 2
 default_nodepool_vm_type    = "e2-standard-8"
 

--- a/examples/sample-input-ha.tfvars
+++ b/examples/sample-input-ha.tfvars
@@ -27,7 +27,7 @@ postgres_servers = {
 }
 
 # GKE config
-kubernetes_version = "1.23.8-gke.1900"
+kubernetes_version = "1.23.14-gke.401"
 default_nodepool_min_nodes = 2
 default_nodepool_vm_type    = "e2-standard-8"
 

--- a/examples/sample-input-minimal.tfvars
+++ b/examples/sample-input-minimal.tfvars
@@ -27,7 +27,7 @@ tags = {} # e.g., { "key1" = "value1", "key2" = "value2" }
 # }
 
 # GKE config
-kubernetes_version = "1.23.8-gke.1900"
+kubernetes_version = "1.23.14-gke.401"
 default_nodepool_min_nodes = 1
 default_nodepool_vm_type   = "n2-standard-2"
 

--- a/examples/sample-input.tfvars
+++ b/examples/sample-input.tfvars
@@ -27,7 +27,7 @@ postgres_servers = {
 }
 
 # GKE config
-kubernetes_version = "1.23.8-gke.1900"
+kubernetes_version = "1.23.14-gke.401"
 default_nodepool_min_nodes = 2
 default_nodepool_vm_type    = "e2-standard-8"
 


### PR DESCRIPTION
### Changes
Update `kubernetes_version` to `1.23.14-gke.401` in the example .tfvars
  
Earlier this week `1.23.8-gke.1900` the default GCP K8s version that we have in the example file has been removed
Release Notes: https://cloud.google.com/kubernetes-engine/docs/release-notes#December_05_2022

### Tests
See internal ticket 

|Scenario|Deployment Method|Security|K8s Version|Orchestration|Provider|Cadence|Postgres|V4_DEPLOYMENT_OPERATOR_ENABLED|
| --- | --- | --- | --- | --- | --- | --- | --- | --- |
|1|docker|front-door|1.23.14-gke.401|Deploy|GCP|fast:2020|internal|FALSE||