### PR TITLE
docs: (IAC-864) Update SAS Viya name in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,18 +2,18 @@
 
 ## Overview
 
-This project contains Terraform scripts to provision Google GCP infrastructure resources required to deploy SAS Viya 4 products. Here is a list of resources this project can create -
+This project contains Terraform scripts to provision Google GCP infrastructure resources required to deploy SAS Viya 4 platform products. Here is a list of resources this project can create -
 
   >- VPC Network and Network Firewalls
   >- Managed Google Kubernetes Engine (GKE) cluster
   >- System and User GKE Node pools with required Labels and Taints
-  >- Infrastructure to deploy SAS Viya CAS in SMP or MPP mode
-  >- Shared Storage options for SAS Viya -  Google Filestore (ha) or NFS Server (standard)
+  >- Infrastructure to deploy SAS Viya platform CAS in SMP or MPP mode
+  >- Shared Storage options for SAS Viya platform -  Google Filestore (ha) or NFS Server (standard)
   >- Google Cloud SQL for PostgreSQL instance, optional
 
 [<img src="./docs/images/viya4-iac-gcp-diag.png" alt="Architecture Diagram" width="750"/>](./docs/images/viya4-iac-gcp-diag.png?raw=true)
 
-Once the cloud resources are provisioned, see the [viya4-deployment](https://github.com/sassoftware/viya4-deployment) repo to deploy SAS Viya 4 products. If you need more information on the SAS Viya 4 products refer to the official [SAS&reg; Viya&reg; 4 Operations](https://go.documentation.sas.com/?cdcId=itopscdc&cdcVersion=v_001LTS&docsetId=itopswlcm&docsetTarget=home.htm&locale=en) documentation for more details.
+Once the cloud resources are provisioned, see the [viya4-deployment](https://github.com/sassoftware/viya4-deployment) repo to deploy SAS Viya 4 platform products. If you need more information on the SAS Viya 4 platform products refer to the official [SAS&reg; Viya&reg; platform Operations](https://go.documentation.sas.com/?cdcId=itopscdc&cdcVersion=v_001LTS&docsetId=itopswlcm&docsetTarget=home.htm&locale=en) documentation for more details.
 
 ## Prerequisites
 

--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -264,7 +264,7 @@ Each server element, like `foo = {}`, can contain none, some, or all of the para
 | backup_count | The number of automated backups to retain, from 1 to 365 | string | "7" | Take note this is a **COUNT** not number of days |
 | administrator_login | The Administrator Login for the PostgreSQL Server. Changing this forces a new resource to be created. | string | "pgadmin" | | |
 | administrator_password | The Password associated with the administrator_login for the PostgreSQL Server | string | "my$up3rS3cretPassw0rd" |  |
-| server_version | The version of the  PostgreSQL server instance | string | "13" | Refer to the [Viya 4 Administration Guide](https://go.documentation.sas.com/doc/en/sasadmincdc/default/itopssr/p05lfgkwib3zxbn1t6nyihexp12n.htm?fromDefault=#p1wq8ouke3c6ixn1la636df9oa1u) for the supported versions of PostgreSQL for SAS Viya. |
+| server_version | The version of the  PostgreSQL server instance | string | "13" | Refer to the [SAS Viya Platform Administration Guide](https://go.documentation.sas.com/doc/en/sasadmincdc/default/itopssr/p05lfgkwib3zxbn1t6nyihexp12n.htm?fromDefault=#p1wq8ouke3c6ixn1la636df9oa1u) for the supported versions of PostgreSQL for the SAS Viya platform. |
 | ssl_enforcement_enabled | Enforce SSL on connection to the PostgreSQL database | bool | true | |
 | availability_type | The availability type for the master instance. | string | "ZONAL" | This is only used to set up high availability for the PostgreSQL instance. Can be either `ZONAL` or `REGIONAL`. |
 | database_flags | Database flags for the master instance. | list(object({})) |  | More details can be found [here](https://cloud.google.com/sql/docs/postgres/flags) |

--- a/docs/sas-updates.md
+++ b/docs/sas-updates.md
@@ -1,9 +1,9 @@
-New in SAS Viya 2021.2.6: the connect workload class is no longer required. For more information, see [Connect Workload Class Changes](https://go.documentation.sas.com/doc/en/itopscdc/v_026/itopswn/n0jh2fbifqgoksn1uou9p2zgbzdy.htm#p15778dvqwzjtgn1e95nq9v0y1wv).
+New in the SAS Viya platform 2021.2.6: the connect workload class is no longer required. For more information, see [Connect Workload Class Changes](https://go.documentation.sas.com/doc/en/itopscdc/v_026/itopswn/n0jh2fbifqgoksn1uou9p2zgbzdy.htm#p15778dvqwzjtgn1e95nq9v0y1wv).
  
-To deploy SAS Viya 2021.2.6 and later, use the most recent version of SAS Viya 4 Infrastructure as Code. The default settings do not create a connect node pool. If your current software order has a requirement for the connect node pool, you can use the connect node pool example file in `examples/sample-input-connect.tfvars`.
+To deploy the SAS Viya platform 2021.2.6 and later, use the most recent version of SAS Viya 4 Infrastructure as Code. The default settings do not create a connect node pool. If your current software order has a requirement for the connect node pool, you can use the connect node pool example file in `examples/sample-input-connect.tfvars`.
  
-If you are updating SAS Viya to version 2021.2.6, take some additional steps to remove the connect nodes.
+If you are updating the SAS Viya platform to version 2021.2.6, take some additional steps to remove the connect nodes.
 
-1.	Perform the update by following the steps in the [SAS Viya documentation](https://go.documentation.sas.com/doc/en/itopscdc/default/k8sag/p043aa4ghwwom6n1beyfifdgkve7.htm). 
+1.	Perform the update by following the steps in the [SAS Viya platform documentation](https://go.documentation.sas.com/doc/en/itopscdc/default/k8sag/p043aa4ghwwom6n1beyfifdgkve7.htm). 
 2.	When the update to 2021.2.6 has completed successfully, use the `examples/sample-input.tfvars` file or edit your customized variable definition file (tfvars) to remove `connect={}` from the "node_pools" section.
 3.	Run `terraform apply` using your edited tfvars file.


### PR DESCRIPTION
### Changes
Updating the SAS Viya name in the documentation

### Note: 

The repo's "About" section will also need to change as part of this PR, since that's not controlled by the code I'll put the updated content here. Please review this as well.


>This project contains Terraform configuration files to provision infrastructure components required to deploy SAS Viya platform products on Google GCP.
