### PR TITLE
feat: (IAC-901) Add K8s 1.25 support and Support Aliased Versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG GCP_CLI_VERSION=409.0.0
 FROM hashicorp/terraform:$TERRAFORM_VERSION as terraform
 
 FROM google/cloud-sdk:$GCP_CLI_VERSION
-ARG KUBECTL_VERSION=1.23.8
+ARG KUBECTL_VERSION=1.24.10
 
 WORKDIR /viya4-iac-gcp
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Operational knowledge of
 - Terraform or Docker
   - #### Terraform
     - [Terraform](https://www.terraform.io/downloads.html) - v1.0.0
-    - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl) - v1.23.8
+    - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl) - v1.24.10
     - [jq](https://stedolan.github.io/jq/) - v1.6
     - [gcloud CLI](https://cloud.google.com/sdk/gcloud) - (optional - useful as an alternative to the Google Cloud Platform Portal) - v409.0.0
   - #### Docker

--- a/config/sample-input-tf-enterprise.tfvars
+++ b/config/sample-input-tf-enterprise.tfvars
@@ -8,7 +8,7 @@
 # NOTE: For Terraform Cloud/Enterprise these variables should be defined
 #       in the workspace in terraform cloud/enterprise as a terraform variable
 #
-#       You also need to define: GOOGLE_CREDENTIALS as an envrionment
+#       You also need to define: GOOGLE_CREDENTIALS as an environment
 #       variable.
 # prefix         = "<prefix-value>"
 # location       = "<gcp-zone-or-region>" # e.g., "us-east1-b"
@@ -38,7 +38,7 @@ create_static_kubeconfig = true
 # tags = {} # e.g., { "key1" = "value1", "key2" = "value2" }
 
 # GKE config
-kubernetes_version         = "1.23.8-gke.1900"
+kubernetes_version         = "1.24"
 default_nodepool_min_nodes = 1
 default_nodepool_vm_type   = "n2-standard-2"
 

--- a/docs/user/KubernetesVersions.md
+++ b/docs/user/KubernetesVersions.md
@@ -72,7 +72,7 @@ Do not set the `kubernetes_channel` variable.
 
 ### Aliased Versions
 
-Only applicable in the "version based" scenario, Google supports the use of [aliased versions](https://cloud.google.com/kubernetes-engine/versioning#specifying_cluster_version) when creating your kubernetes cluster. The format required looks like:
+Only applicable in the "version based" scenario (omitting `kubernetes_channel` or setting it to "UNSPECIFIED"), Google supports the use of [aliased versions](https://cloud.google.com/kubernetes-engine/versioning#specifying_cluster_version) when creating your kubernetes cluster. The format required looks like:
 
 * 1.X
   * Specifies the highest valid patch+gke.N patch release in the 1.X minor version

--- a/docs/user/KubernetesVersions.md
+++ b/docs/user/KubernetesVersions.md
@@ -60,7 +60,7 @@ validMasterVersions:
 
 **NOTE**: This value will also be the value applied to the compute nodes of your custer.
 
-From here you would take one of these values and set the `kubernetes_version` variable in your tfvars files like this:
+To set the exact version for your cluster, you would take one of these values and set the `kubernetes_version` variable in your tfvars files like so:
 
 ```terraform
 kubernetes_version = "1.24.9-gke.3200"

--- a/docs/user/KubernetesVersions.md
+++ b/docs/user/KubernetesVersions.md
@@ -31,43 +31,75 @@ export LOCATION="us-east1-b"
 gcloud container get-server-config --format "yaml(validMasterVersions)" --zone $LOCATION
 Fetching server config for us-east1-b
 validMasterVersions:
-- 1.18.16-gke.1200
-- 1.18.16-gke.500
-- 1.18.16-gke.302
-- 1.18.16-gke.300
-- 1.18.15-gke.1502
-- 1.18.15-gke.1501
-- 1.18.15-gke.1500
-- 1.18.15-gke.1102
-- 1.18.15-gke.1100
-- 1.18.14-gke.1600
-- 1.18.14-gke.1200
-- 1.18.12-gke.1210
-- 1.17.17-gke.3700
-- 1.17.17-gke.3000
-- 1.17.17-gke.2800
-- 1.17.17-gke.1500
-- 1.17.17-gke.1101
-- 1.17.17-gke.1100
-- 1.17.15-gke.800
-- 1.16.15-gke.12500
-- 1.16.15-gke.11800
-- 1.16.15-gke.10600
-- 1.16.15-gke.7801
-- 1.15.12-gke.6002
+- 1.25.6-gke.1000
+- 1.25.6-gke.200
+- 1.25.5-gke.2000
+- 1.24.9-gke.3200
+- 1.24.9-gke.2000
+- 1.24.9-gke.1500
+- 1.24.8-gke.2000
+- 1.23.16-gke.1100
+- 1.23.16-gke.200
+- 1.23.15-gke.1900
+- 1.23.15-gke.1400
+- 1.23.14-gke.1800
+- 1.23.14-gke.401
+- 1.23.13-gke.900
+- 1.22.17-gke.4000
+- 1.22.17-gke.3100
+- 1.22.16-gke.2000
+- 1.22.16-gke.1300
+- 1.22.15-gke.2500
+- 1.22.15-gke.1000
+- 1.21.14-gke.15800
+- 1.21.14-gke.14600
+- 1.21.14-gke.14100
+- 1.21.14-gke.8500
+- 1.21.14-gke.7100
 ```
 
 **NOTE**: This value will also be the value applied to the compute nodes of your custer.
 
-From here you would take one of these values and set the `kubernets_version` variable in your tfvars files like this:
+From here you would take one of these values and set the `kubernetes_version` variable in your tfvars files like this:
 
-```bash
-kubernetes_version = "1.18.15-gke.1102"
+```terraform
+kubernetes_version = "1.24.9-gke.3200"
 ```
 
 Do not set the `kubernetes_channel` variable.
 
 **NOTE**: If you find that the version you would like to use in your kubernetes cluster is not listed, you will need to go the [Channel Based](#channel-based) section to find the desired version.
+
+### Aliased Version
+
+Only applicable in the version based scenario, Google supports the use of [aliased versions](https://cloud.google.com/kubernetes-engine/versioning#specifying_cluster_version) when creating your kubernetes cluster. The format required looks like:
+
+* 1.X
+  * Specifies the highest valid patch+gke.N patch release in the 1.X minor version
+* 1.X.Y
+  * Specifies the highest valid gke.N patch in the 1.X.Y patch release.
+
+
+**Example: 1.X Format**
+
+In your tfvars you would set the `kubernetes_version` variable in like so:
+
+```terraform
+kubernetes_version = "1.24"
+```
+
+Going by the list of versions from the output of the `gcloud container get-server-config` command above, this assignment results in a cluster being created with the version `1.24.9-gke.3200`, since Google chooses the "highest valid patch+gke.N patch release in the 1.24 minor version"
+
+**Example: 1.X.Y Format**
+
+In your tfvars you would set the `kubernetes_version` variable in like so:
+
+```terraform
+kubernetes_version = "1.23.15"
+```
+
+Going by the list of versions from the output of the `gcloud container get-server-config` command above, this assignment results in a cluster being created with the version `1.23.15-gke.1900`, since Google chooses the "highest valid gke.N patch in the 1.23.15 patch release."
+
 
 ## Channel Based
 
@@ -90,33 +122,43 @@ gcloud container get-server-config --format "yaml(channels)" --zone $LOCATION
 Fetching server config for us-east1-b
 channels:
 - channel: RAPID
-  defaultVersion: 1.19.8-gke.1000
+  defaultVersion: 1.25.6-gke.200
   validVersions:
-  - 1.20.4-gke.1800
-  - 1.19.8-gke.1600
-  - 1.19.8-gke.1000
+  - 1.26.1-gke.200
+  - 1.25.6-gke.1000
+  - 1.25.6-gke.200
+  - 1.24.9-gke.3200
+  - 1.23.16-gke.1100
+  - 1.23.16-gke.200
+  - 1.22.17-gke.4000
+  - 1.22.17-gke.3100
+  - 1.21.14-gke.15800
 - channel: REGULAR
-  defaultVersion: 1.18.15-gke.1501
+  defaultVersion: 1.24.9-gke.2000
   validVersions:
-  - 1.18.16-gke.302
-  - 1.18.15-gke.1502
-  - 1.18.15-gke.1501
+  - 1.25.5-gke.2000
+  - 1.24.9-gke.2000
+  - 1.23.14-gke.1800
+  - 1.22.16-gke.2000
+  - 1.21.14-gke.14600
 - channel: STABLE
-  defaultVersion: 1.17.17-gke.1101
+  defaultVersion: 1.23.14-gke.1800
   validVersions:
-  - 1.17.17-gke.2800
-  - 1.17.17-gke.1101
-  - 1.16.15-gke.7801
+  - 1.24.9-gke.1500
+  - 1.23.14-gke.1800
+  - 1.22.16-gke.2000
+  - 1.21.14-gke.14600
+  - 1.21.14-gke.14100
 ```
 
-From this example output if you are looking to create a kubernetes cluster with v1.19 then you would choose the 'RAPID' channel.
+From this example output if you are looking to create a kubernetes cluster with v1.25 then you would choose the 'RAPID' channel.
 
 From here you would set the `kubernetes_channel` variable in your tfvars files like this:
 
-```bash
+```terraform
 kubernetes_channel = "RAPID"
 ```
 
-This assignment results in a cluster being created with the version: `1.19.8-gke.1000` for this example.
+This assignment results in a cluster being created with the version: `1.25.6-gke.200` for this example.
 
 Do not set the `kubernetes_version` variable.

--- a/docs/user/KubernetesVersions.md
+++ b/docs/user/KubernetesVersions.md
@@ -70,9 +70,9 @@ Do not set the `kubernetes_channel` variable.
 
 **NOTE**: If you find that the version you would like to use in your kubernetes cluster is not listed, you will need to go the [Channel Based](#channel-based) section to find the desired version.
 
-### Aliased Version
+### Aliased Versions
 
-Only applicable in the version based scenario, Google supports the use of [aliased versions](https://cloud.google.com/kubernetes-engine/versioning#specifying_cluster_version) when creating your kubernetes cluster. The format required looks like:
+Only applicable in the "version based" scenario, Google supports the use of [aliased versions](https://cloud.google.com/kubernetes-engine/versioning#specifying_cluster_version) when creating your kubernetes cluster. The format required looks like:
 
 * 1.X
   * Specifies the highest valid patch+gke.N patch release in the 1.X minor version

--- a/examples/sample-input-byo.tfvars
+++ b/examples/sample-input-byo.tfvars
@@ -37,7 +37,7 @@ postgres_servers = {
 }
 
 # GKE config
-kubernetes_version         = "1.23.14-gke.401"
+kubernetes_version         = "1.24"
 default_nodepool_min_nodes = 2
 default_nodepool_vm_type   = "e2-standard-8"
 

--- a/examples/sample-input-connect.tfvars
+++ b/examples/sample-input-connect.tfvars
@@ -27,7 +27,7 @@ postgres_servers = {
 }
 
 # GKE config
-kubernetes_version         = "1.23.14-gke.401"
+kubernetes_version         = "1.24"
 default_nodepool_min_nodes = 2
 default_nodepool_vm_type   = "e2-standard-8"
 

--- a/examples/sample-input-ha.tfvars
+++ b/examples/sample-input-ha.tfvars
@@ -27,7 +27,7 @@ postgres_servers = {
 }
 
 # GKE config
-kubernetes_version         = "1.23.14-gke.401"
+kubernetes_version         = "1.24"
 default_nodepool_min_nodes = 2
 default_nodepool_vm_type   = "e2-standard-8"
 

--- a/examples/sample-input-minimal.tfvars
+++ b/examples/sample-input-minimal.tfvars
@@ -27,7 +27,7 @@ tags = {} # e.g., { "key1" = "value1", "key2" = "value2" }
 # }
 
 # GKE config
-kubernetes_version         = "1.23.14-gke.401"
+kubernetes_version         = "1.24"
 default_nodepool_min_nodes = 1
 default_nodepool_vm_type   = "n2-standard-2"
 

--- a/examples/sample-input.tfvars
+++ b/examples/sample-input.tfvars
@@ -27,7 +27,7 @@ postgres_servers = {
 }
 
 # GKE config
-kubernetes_version         = "1.23.14-gke.401"
+kubernetes_version         = "1.24"
 default_nodepool_min_nodes = 2
 default_nodepool_vm_type   = "e2-standard-8"
 

--- a/variables.tf
+++ b/variables.tf
@@ -54,11 +54,8 @@ variable "kubernetes_version" {
   default = "latest"
 
   validation {
-    condition     = (can(regex("^\\d.\\d+.\\d+-gke.\\d+$", var.kubernetes_version)) || var.kubernetes_version == "latest" || can(regex("^\\d.\\d+$", var.kubernetes_version)) || can(regex("^\\d.\\d+.\\d+$", var.kubernetes_version)) )
+    condition     = (can(regex("^\\d.\\d+.\\d+-gke.\\d+$", var.kubernetes_version)) || var.kubernetes_version == "latest" || can(regex("^\\d.\\d+$", var.kubernetes_version)) || can(regex("^\\d.\\d+.\\d+$", var.kubernetes_version)))
     error_message = "The format for kubernetes version is: major.minor.patch-gke.N, major.minor, major.minor.patch, or 'latest'."
-#   condition     = (can(regex("^\\d.\\d+.\\d+-gke.\\d+$", var.kubernetes_version)) || var.kubernetes_version == "latest")
-#   error_message = "The format for kubernetes version is: x.yy-gke.zzzz or 'latest'."
-
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -54,8 +54,11 @@ variable "kubernetes_version" {
   default = "latest"
 
   validation {
-    condition     = (can(regex("^\\d.\\d+.\\d+-gke.\\d+$", var.kubernetes_version)) || var.kubernetes_version == "latest")
-    error_message = "The format for kubernetes version is: x.yy-gke.zzzz or 'latest'."
+    condition     = (can(regex("^\\d.\\d+.\\d+-gke.\\d+$", var.kubernetes_version)) || var.kubernetes_version == "latest" || can(regex("^\\d.\\d+$", var.kubernetes_version)) || can(regex("^\\d.\\d+.\\d+$", var.kubernetes_version)) )
+    error_message = "The format for kubernetes version is: major.minor.patch-gke.N, major.minor, major.minor.patch, or 'latest'."
+#   condition     = (can(regex("^\\d.\\d+.\\d+-gke.\\d+$", var.kubernetes_version)) || var.kubernetes_version == "latest")
+#   error_message = "The format for kubernetes version is: x.yy-gke.zzzz or 'latest'."
+
   }
 }
 


### PR DESCRIPTION
### Changes

Since the SAS Viya Platform will be supporting K8s 1.23, 1.24, and 1.25 in March as part of the 2023.03 cadence, the kubectl version is being changed to 1.24.10 so that it's within the +/- 1 range of the supported versions. 

We've also now added support for using aliased kubernetes versions.

This is only applicable in the "version based" scenario (omitting `kubernetes_channel` or setting it to "UNSPECIFIED"), Google supports the use of [aliased versions](https://cloud.google.com/kubernetes-engine/versioning#specifying_cluster_version) when creating your kubernetes cluster. The required format for using aliased versions in your tfvars for `kubernetes_version` looks like:

* 1.X
  * Specifies the highest valid patch+gke.N patch release in the 1.X minor version
* 1.X.Y
  * Specifies the highest valid gke.N patch in the 1.X.Y patch release.

For example you could set:

```terraform
kubernetes_version = "1.24"
```
And Google will choose the "highest valid patch+gke.N patch release in the 1.24 minor version" they currently have available.

Setting the full version like before is still supported. (e.g. 1.24.9-gke.3200)

The [Kubernetes Versions](https://github.com/sassoftware/viya4-iac-gcp/blob/IAC-901/docs/user/KubernetesVersions.md) documentation has been updated to describe this usage


### Tests

Ran through the following scenarios, the internal ticket has more details.

|Scenario|Task|Provider|Order|Cadence|kubernetes_version|Actual Kubernetes Cluster Version|Orchestration|Deployment Method|kubectl Version|INGRESS_NGINX_CHART_VERSION|
|:----|:----|:----|:----|:----|:----|:----|:----|:----|:----|:----|
|1|OOTB|GCP|------|stable:2023.02|1.24|1.24.9-gke.3200|Deployment Operator|Docker|1.24.10|4.3.0|
|2|OOTB|GCP|------|stable:2023.01|1.23.15|1.23.15-gke.1900|Deployment Operator|Docker|1.24.10|4.3.0|
|3|OOTB + Logging Monitoring|GCP|------|fast:2020|1.25.6-gke.200|1.25.6-gke.200|Deployment Operator|Docker|1.24.10|4.3.0|
