### PR TITLE
feat: (IAC-895) Add Support to Toggle the Google Cloud Managed Service for Prometheus

### DIFF
--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -20,6 +20,7 @@ Supported configuration variables are listed in the table below.  All variables 
     - [For `storage_type=ha` only (Google Filestore)](#for-storage_typeha-only-google-filestore)
   - [Google Container Registry (GCR)](#google-container-registry-gcr)
   - [Postgres Servers](#postgres-servers)
+  - [Monitoring](#monitoring)
 
 Terraform input variables can be set in the following ways:
 - Individually, with the [-var command line option](https://www.terraform.io/docs/configuration/variables.html#variables-on-the-command-line).
@@ -293,3 +294,11 @@ postgres_servers = {
   }
 }
 ```
+
+## Monitoring
+
+Each server element, like `foo = {}`, can contain none, some, or all of the parameters listed below:
+
+| Name | Description | Type | Default | Notes |
+| :--- | ---: | ---: | ---: | ---: |
+| enable_managed_prometheus| Enable Google Cloud Managed Service for Prometheus for your cluster | boolean | false | |

--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -299,4 +299,4 @@ postgres_servers = {
 
 | Name | Description | Type | Default | Notes |
 | :--- | ---: | ---: | ---: | ---: |
-| enable_managed_prometheus| Enable Google Cloud Managed Service for Prometheus for your cluster | boolean | false | |
+| enable_managed_prometheus| Enable Google Cloud [Managed Service for Prometheus](https://cloud.google.com/stackdriver/docs/managed-prometheus) for your cluster | boolean | false | |

--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -297,8 +297,6 @@ postgres_servers = {
 
 ## Monitoring
 
-Each server element, like `foo = {}`, can contain none, some, or all of the parameters listed below:
-
 | Name | Description | Type | Default | Notes |
 | :--- | ---: | ---: | ---: | ---: |
 | enable_managed_prometheus| Enable Google Cloud Managed Service for Prometheus for your cluster | boolean | false | |

--- a/main.tf
+++ b/main.tf
@@ -88,7 +88,7 @@ data "google_container_engine_versions" "gke-version" {
 
 module "gke" {
   source                        = "terraform-google-modules/kubernetes-engine/google//modules/private-cluster"
-  version                       = "23.1.0"
+  version                       = "25.0.0"
   project_id                    = var.project
   name                          = "${var.prefix}-gke"
   region                        = local.region
@@ -120,7 +120,27 @@ module "gke" {
 
   monitoring_service = var.create_gke_monitoring_service ? var.gke_monitoring_service : "none"
 
-  cluster_autoscaling = var.enable_cluster_autoscaling ? { enabled : true, max_cpu_cores : var.cluster_autoscaling_max_cpu_cores, max_memory_gb : var.cluster_autoscaling_max_memory_gb, min_cpu_cores : 1, min_memory_gb : 1, gpu_resources = [] } : { enabled : false, max_cpu_cores : 0, max_memory_gb : 0, min_cpu_cores : 0, min_memory_gb : 0, gpu_resources = [] }
+  monitoring_enable_managed_prometheus = var.enable_managed_prometheus
+
+  cluster_autoscaling = var.enable_cluster_autoscaling ? {
+    enabled : true,
+    max_cpu_cores : var.cluster_autoscaling_max_cpu_cores,
+    max_memory_gb : var.cluster_autoscaling_max_memory_gb,
+    min_cpu_cores : 1,
+    min_memory_gb : 1,
+    gpu_resources = [],
+    auto_repair   = (var.kubernetes_channel == "UNSPECIFIED") ? false : true,
+    auto_upgrade  = (var.kubernetes_channel == "UNSPECIFIED") ? false : true
+    } : {
+    enabled : false,
+    max_cpu_cores : 0,
+    max_memory_gb : 0,
+    min_cpu_cores : 0,
+    min_memory_gb : 0,
+    gpu_resources = [],
+    auto_repair   = (var.kubernetes_channel == "UNSPECIFIED") ? false : true,
+    auto_upgrade  = (var.kubernetes_channel == "UNSPECIFIED") ? false : true
+  }
 
   master_authorized_networks = concat([
     for cidr in(local.cluster_endpoint_public_access_cidrs) : {

--- a/variables.tf
+++ b/variables.tf
@@ -350,7 +350,7 @@ variable "enable_registry_access" {
   default     = true
 }
 
-# Azure Monitor
+# GKE Monitoring
 variable "create_gke_monitoring_service" {
   type        = bool
   description = "Enable GKE metrics from pods in the cluster to the Google Cloud Monitoring API."
@@ -361,6 +361,12 @@ variable "gke_monitoring_service" {
   type        = string
   description = "Value of the Google Cloud Monitoring API to use if monitoring is enabled. Values are: monitoring.googleapis.com, monitoring.googleapis.com/kubernetes, none"
   default     = "none"
+}
+
+variable "enable_managed_prometheus" {
+  type        = bool
+  description = "Enable Google Cloud Managed Service for Prometheus for your cluster"
+  default     = "false"
 }
 
 # Network

--- a/versions.tf
+++ b/versions.tf
@@ -4,11 +4,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "4.38.0"
+      version = "4.55.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "4.38.0"
+      version = "4.55.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"


### PR DESCRIPTION
### Changes

After March 15, 2023 all newly created Google Kubernetes Engine standard clusters will have [Managed Service for Prometheus](https://cloud.google.com/stackdriver/docs/managed-prometheus) in-cluster components deployed by default.

This default enabled feature from Google does add a small amount of cost. See https://cloud.google.com/stackdriver/pricing#mgd-prometheus-pricing-summary

In order to support users who do want this service in their cluster by default we are adding the `enable_managed_prometheus` to control the deployment of the  "Managed Service for Prometheus" in their clusters. By default we are setting this value to false.

### Tests
On hold till March 16 when the "Google Cloud Managed Service for Prometheus" is enabled by default by Google