### PR TITLE
feat: (IAC-74) Support Multi-zonal Cluster Creation

### DIFF
--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -107,7 +107,7 @@ The application of a Kubernetes version in GCP has some limitations when assigni
 | cluster_autoscaling_max_cpu_cores | MAX number of cores in the cluster | number | 500 | |
 | cluster_autoscaling_max_memory_gb | MAX number of gb of memory in the cluster | number | 10000 | |
 | create_static_kubeconfig | Allows the user to create a provider / service account based kube config file | bool | true | A value of `false` will default to using the cloud providers mechanism for generating the kubeconfig file. A value of `true` will create a static kubeconfig which utilizes a `Service Account` and `Cluster Role Binding` to provide credentials. |
-| regional | Create a regional GKE control plane | bool | true | If false a zonal GKE control plane is created |
+| regional | Create a regional GKE control plane | bool | true | If false a zonal GKE control plane is created. **WARNING: changing this after cluster creation is destructive** |
 | create_jump_vm | Create bastion host | bool | true | |
 | create_jump_public_ip | Add public ip to jump VM | bool | true | |
 | jump_vm_admin | OS Admin User for the Jump VM | string | "jumpuser" | |

--- a/locals.tf
+++ b/locals.tf
@@ -55,7 +55,7 @@ locals {
       vm_type            = settings.vm_type
       node_taints        = settings.accelerator_count > 0 ? concat(settings.node_taints, ["nvidia.com/gpu=present:NoSchedule"]) : settings.node_taints
       initial_node_count = max(local.initial_node_count, settings.min_nodes)
-      node_locations     = var.nodepools_locations	!= "" ? var.nodepools_locations : local.zone
+      node_locations     = var.nodepools_locations	!= "" && var.nodepools_locations != null ? var.nodepools_locations : local.zone
     }
   }
 
@@ -71,7 +71,7 @@ locals {
       "accelerator_count"  = 0
       "accelerator_type"   = ""
       "initial_node_count" = var.default_nodepool_min_nodes
-      "node_locations"     = var.default_nodepool_locations	!= "" ? var.default_nodepool_locations : local.zone
+      "node_locations"     = var.default_nodepool_locations	!= "" && var.default_nodepool_locations != null ? var.default_nodepool_locations : local.zone
     }
   })
 

--- a/locals.tf
+++ b/locals.tf
@@ -55,6 +55,7 @@ locals {
       vm_type            = settings.vm_type
       node_taints        = settings.accelerator_count > 0 ? concat(settings.node_taints, ["nvidia.com/gpu=present:NoSchedule"]) : settings.node_taints
       initial_node_count = max(local.initial_node_count, settings.min_nodes)
+      node_locations     = var.nodepools_locations	!= "" ? var.nodepools_locations : local.zone
     }
   }
 
@@ -70,6 +71,7 @@ locals {
       "accelerator_count"  = 0
       "accelerator_type"   = ""
       "initial_node_count" = var.default_nodepool_min_nodes
+      "node_locations"     = var.default_nodepool_locations	!= "" ? var.default_nodepool_locations : local.zone
     }
   })
 

--- a/main.tf
+++ b/main.tf
@@ -141,7 +141,7 @@ module "gke" {
     for nodepool, settings in local.node_pools : {
       name               = nodepool
       machine_type       = settings.vm_type
-      node_locations     = local.zone # This must be a zone not a region. So var.location may not always work. ;)
+      node_locations     = settings.node_locations
       min_count          = settings.min_nodes
       max_count          = settings.max_nodes
       node_count         = (settings.min_nodes == settings.max_nodes) ? settings.min_nodes : null

--- a/outputs.tf
+++ b/outputs.tf
@@ -17,7 +17,7 @@ output "kube_config" {
   sensitive = true
 }
 
-#postgres
+# postgres
 output "postgres_servers" {
   value     = length(module.postgresql) != 0 ? local.postgres_outputs : null
   sensitive = true
@@ -90,7 +90,7 @@ output "nfs_admin_username" {
   value = var.storage_type == "standard" ? module.nfs_server.0.admin_username : null
 }
 
-# Container regsitry
+# Container registry
 output "cr_endpoint" {
   value = var.enable_registry_access ? "https://gcr.io/${var.project}" : null
 }

--- a/variables.tf
+++ b/variables.tf
@@ -196,6 +196,13 @@ variable "default_nodepool_labels" {
   default = {}
 }
 
+# Multi-zonal cluster support - Experimental
+variable "default_nodepool_locations" {
+  description = "GCP zone(s) where the default nodepool will allocate nodes in. Comma separated list."
+  type    = string
+  default = ""
+}
+
 variable "node_pools" {
   description = "Node pool definitions"
   type = map(object({
@@ -264,6 +271,22 @@ variable "node_pools" {
       "accelerator_type"  = ""
     }
   }
+}
+
+# Multi-zonal cluster support - Experimental
+# TODO - NOTE
+#   This was made external to the node_pools map variable since a requirement of terraform v1.0.0 (the minimum version
+#   we require, see versions.tf) is that for variables with nested fields, all attributes are required otherwise
+#   execution fails.
+#   In Terraform v1.3+ you can mark nested attributes as optional.
+#   Since this is an experimental change, at the moment I do no want to impose new requirements on existing users.
+#   Potentially we upgrade Terraform modules and versions and we bump our minimum required terraform version to be >1.3
+#   then at that time I can deprecate this variable and instead allow the user to configure node_locations per node pool.
+#   Refer to https://github.com/hashicorp/terraform/issues/29407#issuecomment-1150491619
+variable "nodepools_locations" {
+  description = "GCP zone(s) where the additional node pools will allocate nodes in. Comma separated list."
+  type    = string
+  default = ""
 }
 
 variable "enable_cluster_autoscaling" {

--- a/variables.tf
+++ b/variables.tf
@@ -196,7 +196,7 @@ variable "default_nodepool_labels" {
   default = {}
 }
 
-# Multi-zonal cluster support - Experimental
+# Multi-zonal cluster support - Experimental - may change, use at your own risk
 variable "default_nodepool_locations" {
   description = "GCP zone(s) where the default nodepool will allocate nodes in. Comma separated list."
   type    = string
@@ -273,7 +273,7 @@ variable "node_pools" {
   }
 }
 
-# Multi-zonal cluster support - Experimental
+# Multi-zonal cluster support - Experimental - may change, use at your own risk
 # TODO - NOTE
 #   This was made external to the node_pools map variable since a requirement of terraform v1.0.0 (the minimum version
 #   we require, see versions.tf) is that for variables with nested fields, all attributes are required otherwise


### PR DESCRIPTION
### Changes

Added new variables to allow the user to control the location of the default node pool as well as any additional node pools in order to support  multi-zonal clusters.

The user can set `nodepools_locations` and `default_nodepool_locations` to a comma separated list of zones where the node pools will allocate nodes into. It's important that these `nodepools_locations` and `default_nodepool_locations` variables only have zones defined that are within the location your specified for the control plane. If `location` for the control plane is set to us-east1 you can only use set the `nodepools_locations` and `default_nodepool_locations` zones to be us-east1-* and not zones from other regions.

if these variables are not set its default value will be the single zone, the first zone found for the value you defined for `location`. This results in the exact same behavior that we had prior to this change. 


It's also important to note that when defining `nodepools_locations` and `default_nodepool_locations` with a list of zones larger than one, the number of nodes that get created becomes multiplicative, Google treats the min_count values max_count values as per zone. Meaning if you defined something like this:

```bash
nodepools_locations="us-east1-c,us-east1-d" 
node_pools = {
cas = {
"vm_type"      = "n1-highmem-16"
"os_disk_size" = 200
"min_nodes"    = 3
"max_nodes"    = 5
"node_taints"  = ["workload.sas.com/class=cas:NoSchedule"]
"node_labels"  = {
"workload.sas.com/class" = "cas"
}
"local_ssd_count"   = 0
"accelerator_count" = 0
"accelerator_type"  = ""
}
```
Google would create at minimum 3 cas nodes per zone, and since we specified two `nodepools_locations` the end result will be 6 total cas nodes (3 per region), and this is without any workloads to require more nodes to be spawned. When this moves out of experimental we will need to emphasize how much cost can increase by the additional node pool location.

### Tests


| Scenario | Provider | K8s Version       | location   | regional             | default_nodepool_locations | nodepools_locations   | Cadence   | Notes                                                                                                                                                                                                           |
|:---------|:---------|:------------------|:-----------|:---------------------|:---------------------------|:----------------------|:----------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| 1        | GCP      | v1.24.12-gke.500  | us-east1-b | unset (default TRUE) | unset (uses location)      | unset (uses location) | fast:2020 | This created a regional cluster (nodes running in a single zone variant). Control plane replicated across all zones in us-east-1 and all nodes were placed in us-east1-b                                        |
| 2        | GCP      | v1.24.11-gke.1000 | us-east1-d | FALSE                | us-east1-b,us-east1-d      | us-east1-c,us-east1-d | fast:2020 | This created a multi-zonal cluster. Control plane only in us-east1-d, default nodes placed in us-east1-b,us-east1-d, other nodes placed in us-east1-c,us-east1-d                                                |
| 3        | GCP      | v1.24.12-gke.500  | us-east1-d | TRUE                 | us-east1-b,us-east1-d      | us-east1-c,us-east1-d | fast:2020 | This created a regional cluster (nodes running in a multi zone variant). Control plane replicated across all zones,  default nodes placed in us-east1-b,us-east1-d, other nodes placed in us-east1-c,us-east1-d |
| 4        | GCP      | v1.24.11-gke.1000 | us-east1-c | FALSE                | unset (uses location)      | unset (uses location) | fast:2020 | This created a single-zone cluster. Control plane, default nodes, and other nodes in us-east1-c                                                                                                                 |