### PR TITLE
fix: (IAC-1008) Explicitly Set the release_channel when Creating GKE Clusters

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -113,7 +113,7 @@ module "gke" {
 
   add_cluster_firewall_rules = true
 
-  release_channel    = var.kubernetes_channel != "UNSPECIFIED" ? var.kubernetes_channel : null
+  release_channel    = var.kubernetes_channel
   kubernetes_version = var.kubernetes_channel == "UNSPECIFIED" ? var.kubernetes_version : data.google_container_engine_versions.gke-version.release_channel_default_version[var.kubernetes_channel]
 
   network_policy           = var.gke_network_policy


### PR DESCRIPTION
### Changes

When the user sets `UNSPECIFIED` for the `kubernetes_channel` do not set `release_channel` to null and rely on the default value downstream. Instead we will be explicitly setting  `release_channel` it to the value  in  `kubernetes_channel`.

We are doing this because apparently there was a underlying GKE API change where setting the `release_channel` to null would now default to the `REGULAR` channel. It was advised to no longer set this value to null. See this GitHub issue I opened against the `terraform-google-modules/kubernetes-engine` module
https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/issues/1620

They are working on getting the doc updated in the next module release.

Note:
* `kubernetes_channel`: the variable we expose to users in this project to control the release channel
* `release_channel`: the parameter that controls the release channel in the `terraform-google-modules/kubernetes-engine/google//modules/private-cluster` module

### Tests
| Scenario | Provider | kubernetes_version | kubernetes_channel          | Actual K8s Version |
| -------- | -------- | ------------------ | --------------------------- | ------------------ |
| 1        | GCP      | 1.25               | unset (default UNSPECIFIED) | v1.25.8-gke.1000   |
| 2        | GCP      | 1.24.10            | UNSPECIFIED                 | v1.24.10-gke.2300  |
| 3        | GCP      | unset              | REGULAR                     | 1.25.7-gke.1000    |