### PR TITLE
feat!: (IAC-997) (IAC-995) Update viya4-iac-gcp Providers, Modules, & Dependencies and Patch Security Issues

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -251,13 +251,14 @@ module "postgresql" {
   tier      = each.value.machine_type
   disk_size = each.value.storage_gb
 
-  enable_default_db = false
-  user_name         = each.value.administrator_login
-  user_password     = each.value.administrator_password
-  user_labels       = var.tags
-
-  database_version = "POSTGRES_${each.value.server_version}"
-  database_flags   = values(zipmap(concat(local.base_database_flags.*.name, each.value.database_flags.*.name), concat(local.base_database_flags, each.value.database_flags)))
+  enable_default_db        = false
+  user_name                = each.value.administrator_login
+  user_password            = each.value.administrator_password
+  user_labels              = var.tags
+  user_deletion_policy     = "ABANDON"
+  database_deletion_policy = "ABANDON"
+  database_version         = "POSTGRES_${each.value.server_version}"
+  database_flags           = values(zipmap(concat(local.base_database_flags.*.name, each.value.database_flags.*.name), concat(local.base_database_flags, each.value.database_flags)))
 
   backup_configuration = {
     enabled                        = each.value.backups_enabled

--- a/main.tf
+++ b/main.tf
@@ -285,7 +285,7 @@ module "postgresql" {
 
 module "sql_proxy_sa" {
   source        = "terraform-google-modules/service-accounts/google"
-  version       = "4.1.1"
+  version       = "4.2.1"
   count         = var.postgres_servers != null ? length(var.postgres_servers) != 0 ? 1 : 0 : 0
   project_id    = var.project
   prefix        = var.prefix

--- a/modules/google_vm/main.tf
+++ b/modules/google_vm/main.tf
@@ -3,7 +3,7 @@
 
 module "address" {
   source       = "terraform-google-modules/address/google"
-  version      = "3.1.1"
+  version      = "3.1.2"
   project_id   = var.project
   region       = var.region
   address_type = "EXTERNAL"

--- a/network.tf
+++ b/network.tf
@@ -11,7 +11,7 @@ data "google_compute_address" "nat_address" {
 module "nat_address" {
   count        = length(var.nat_address_name) == 0 ? 1 : 0
   source       = "terraform-google-modules/address/google"
-  version      = "3.1.1"
+  version      = "3.1.2"
   project_id   = var.project
   region       = local.region
   address_type = "EXTERNAL"

--- a/network.tf
+++ b/network.tf
@@ -23,7 +23,7 @@ module "nat_address" {
 module "cloud_nat" {
   count         = length(var.nat_address_name) == 0 ? 1 : 0
   source        = "terraform-google-modules/cloud-nat/google"
-  version       = "2.2.1"
+  version       = "3.0.0"
   project_id    = var.project
   name          = "${var.prefix}-cloud-nat"
   region        = local.region

--- a/versions.tf
+++ b/versions.tf
@@ -27,8 +27,7 @@ terraform {
     }
     null = {
       source  = "hashicorp/null"
-      version = "3.1.0" # Constrained by Google
-#      version = "3.2.1" # Constrained by Google # TODO BUMP AFTER UPGRADING PG MODULE
+      version = "3.2.1" # Constrained by Google
     }
     external = {
       source  = "hashicorp/external"

--- a/versions.tf
+++ b/versions.tf
@@ -31,7 +31,7 @@ terraform {
     }
     external = {
       source  = "hashicorp/external"
-      version = "2.2.2" # Constrained by Google
+      version = "2.3.1" # Constrained by Google
     }
     time = {
       source  = "hashicorp/time"

--- a/versions.tf
+++ b/versions.tf
@@ -7,31 +7,28 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "4.38.0"
+      version = "4.63.1"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "4.38.0"
+      version = "4.63.1"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "2.14.0" # Constrained by Google
+      version = "2.20.0" # Constrained by Google
     }
     local = {
       source  = "hashicorp/local"
-      version = "2.2.3"
-    }
-    template = {
-      source  = "hashicorp/template"
-      version = "2.2.0"
+      version = "2.4.0"
     }
     random = {
       source  = "hashicorp/random"
-      version = "3.1.0" # Constrained by Google
+      version = "3.5.1" # Constrained by Google
     }
     null = {
       source  = "hashicorp/null"
       version = "3.1.0" # Constrained by Google
+#      version = "3.2.1" # Constrained by Google # TODO BUMP AFTER UPGRADING PG MODULE
     }
     external = {
       source  = "hashicorp/external"
@@ -39,7 +36,7 @@ terraform {
     }
     time = {
       source  = "hashicorp/time"
-      version = "0.8.0"
+      version = "0.9.1"
     }
   }
 }

--- a/vms.tf
+++ b/vms.tf
@@ -12,42 +12,6 @@ locals {
   )
 }
 
-# TODO DELETE
-#data "template_file" "nfs_cloudconfig" {
-#  # https://blog.woohoosvcs.com/2019/11/cloud-init-on-google-compute-engine/
-#  template = file("${path.module}/files/cloud-init/nfs/cloud-config")
-#  count    = var.storage_type == "standard" ? 1 : 0
-#  vars = {
-#    misc_subnet_cidr = local.misc_subnet_cidr
-#    gke_subnet_cidr  = local.gke_subnet_cidr
-#    vm_admin         = var.nfs_vm_admin
-#  }
-#}
-
-# TODO DELETE
-#data "template_file" "jump_cloudconfig" {
-#  template = file("${path.module}/files/cloud-init/jump/cloud-config")
-#  count    = var.create_jump_vm ? 1 : 0
-#  vars = {
-#    mounts = (var.storage_type == "none"
-#      ? "[]"
-#      : jsonencode(
-#        ["${local.rwx_filestore_endpoint}:${local.rwx_filestore_path}",
-#          "${var.jump_rwx_filestore_path}",
-#          "nfs",
-#          "_netdev,auto,x-systemd.automount,x-systemd.mount-timeout=10,timeo=14,x-systemd.idle-timeout=1min,relatime,hard,rsize=65536,wsize=65536,vers=3,tcp,namlen=255,retrans=2,sec=sys,local_lock=none",
-#          "0",
-#          "0"
-#      ])
-#    )
-#    rwx_filestore_endpoint  = local.rwx_filestore_endpoint
-#    rwx_filestore_path      = local.rwx_filestore_path
-#    vm_admin                = var.jump_vm_admin
-#    jump_rwx_filestore_path = var.jump_rwx_filestore_path
-#  }
-#  depends_on = [module.nfs_server, google_filestore_instance.rwx]
-#}
-
 module "nfs_server" {
   source           = "./modules/google_vm"
   project          = var.project

--- a/vms.tf
+++ b/vms.tf
@@ -12,40 +12,41 @@ locals {
   )
 }
 
+# TODO DELETE
+#data "template_file" "nfs_cloudconfig" {
+#  # https://blog.woohoosvcs.com/2019/11/cloud-init-on-google-compute-engine/
+#  template = file("${path.module}/files/cloud-init/nfs/cloud-config")
+#  count    = var.storage_type == "standard" ? 1 : 0
+#  vars = {
+#    misc_subnet_cidr = local.misc_subnet_cidr
+#    gke_subnet_cidr  = local.gke_subnet_cidr
+#    vm_admin         = var.nfs_vm_admin
+#  }
+#}
 
-data "template_file" "nfs_cloudconfig" {
-  # https://blog.woohoosvcs.com/2019/11/cloud-init-on-google-compute-engine/
-  template = file("${path.module}/files/cloud-init/nfs/cloud-config")
-  count    = var.storage_type == "standard" ? 1 : 0
-  vars = {
-    misc_subnet_cidr = local.misc_subnet_cidr
-    gke_subnet_cidr  = local.gke_subnet_cidr
-    vm_admin         = var.nfs_vm_admin
-  }
-}
-
-data "template_file" "jump_cloudconfig" {
-  template = file("${path.module}/files/cloud-init/jump/cloud-config")
-  count    = var.create_jump_vm ? 1 : 0
-  vars = {
-    mounts = (var.storage_type == "none"
-      ? "[]"
-      : jsonencode(
-        ["${local.rwx_filestore_endpoint}:${local.rwx_filestore_path}",
-          "${var.jump_rwx_filestore_path}",
-          "nfs",
-          "_netdev,auto,x-systemd.automount,x-systemd.mount-timeout=10,timeo=14,x-systemd.idle-timeout=1min,relatime,hard,rsize=65536,wsize=65536,vers=3,tcp,namlen=255,retrans=2,sec=sys,local_lock=none",
-          "0",
-          "0"
-      ])
-    )
-    rwx_filestore_endpoint  = local.rwx_filestore_endpoint
-    rwx_filestore_path      = local.rwx_filestore_path
-    vm_admin                = var.jump_vm_admin
-    jump_rwx_filestore_path = var.jump_rwx_filestore_path
-  }
-  depends_on = [module.nfs_server, google_filestore_instance.rwx]
-}
+# TODO DELETE
+#data "template_file" "jump_cloudconfig" {
+#  template = file("${path.module}/files/cloud-init/jump/cloud-config")
+#  count    = var.create_jump_vm ? 1 : 0
+#  vars = {
+#    mounts = (var.storage_type == "none"
+#      ? "[]"
+#      : jsonencode(
+#        ["${local.rwx_filestore_endpoint}:${local.rwx_filestore_path}",
+#          "${var.jump_rwx_filestore_path}",
+#          "nfs",
+#          "_netdev,auto,x-systemd.automount,x-systemd.mount-timeout=10,timeo=14,x-systemd.idle-timeout=1min,relatime,hard,rsize=65536,wsize=65536,vers=3,tcp,namlen=255,retrans=2,sec=sys,local_lock=none",
+#          "0",
+#          "0"
+#      ])
+#    )
+#    rwx_filestore_endpoint  = local.rwx_filestore_endpoint
+#    rwx_filestore_path      = local.rwx_filestore_path
+#    vm_admin                = var.jump_vm_admin
+#    jump_rwx_filestore_path = var.jump_rwx_filestore_path
+#  }
+#  depends_on = [module.nfs_server, google_filestore_instance.rwx]
+#}
 
 module "nfs_server" {
   source           = "./modules/google_vm"
@@ -65,7 +66,12 @@ module "nfs_server" {
   vm_admin       = var.nfs_vm_admin
   ssh_public_key = local.ssh_public_key
 
-  user_data = length(data.template_file.nfs_cloudconfig) == 1 ? data.template_file.nfs_cloudconfig.0.rendered : null
+  user_data = var.storage_type == "standard" ? templatefile("${path.module}/files/cloud-init/nfs/cloud-config", {
+    misc_subnet_cidr = local.misc_subnet_cidr
+    gke_subnet_cidr  = local.gke_subnet_cidr
+    vm_admin         = var.nfs_vm_admin
+    }
+  ) : null
 
   data_disk_count = 4
   data_disk_size  = var.nfs_raid_disk_size
@@ -91,7 +97,24 @@ module "jump_server" {
   vm_admin       = var.jump_vm_admin
   ssh_public_key = local.ssh_public_key
 
-  user_data = data.template_file.jump_cloudconfig.0.rendered
+  user_data = templatefile("${path.module}/files/cloud-init/jump/cloud-config", {
+    mounts = (var.storage_type == "none"
+      ? "[]"
+      : jsonencode(
+        ["${local.rwx_filestore_endpoint}:${local.rwx_filestore_path}",
+          var.jump_rwx_filestore_path,
+          "nfs",
+          "_netdev,auto,x-systemd.automount,x-systemd.mount-timeout=10,timeo=14,x-systemd.idle-timeout=1min,relatime,hard,rsize=65536,wsize=65536,vers=3,tcp,namlen=255,retrans=2,sec=sys,local_lock=none",
+          "0",
+          "0"
+      ])
+    )
+    rwx_filestore_endpoint  = local.rwx_filestore_endpoint
+    rwx_filestore_path      = local.rwx_filestore_path
+    vm_admin                = var.jump_vm_admin
+    jump_rwx_filestore_path = var.jump_rwx_filestore_path
+    }
+  )
 
-  depends_on = [module.nfs_server]
+  depends_on = [module.nfs_server, google_filestore_instance.rwx]
 }


### PR DESCRIPTION
### Changes

Update the viya4-iac-gcp Providers, Modules, & Dependencies and Patch Security Issues

Below is notes and changes that I made as I upgraded the modules/providers.
#### Providers
##### hashicorp/google & hashicorp/google-beta
* Versions:
  * Initial Version: 4.38.0
  * Final Version: 4.63.1
    * Notes:
      * No notable breaking changes or deprecations observed that would affect us, mostly the addition of new features.
* Change Log: https://github.com/hashicorp/terraform-provider-google/blob/main/CHANGELOG.md
##### hashicorp/kubernetes
* Versions:
  * Initial Version: 2.14.0
  * Final Version: 2.20.0
    * Notes:
      * No notable breaking changes or deprecations observed that would affect us, mostly the addition of new resources.
* Change Log: https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md
##### hashicorp/local
* Versions:
  * Initial Version: 2.2.3
  * Final Version: 2.4.0
    * Notes:
      * No notable breaking changes or deprecations observed that would affect us
* Change Log: https://github.com/hashicorp/terraform-provider-local/blob/main/CHANGELOG.md
##### hashicorp/template
* Versions:
  * Initial Version: 2.2.3
  * Final Version: Removed
    * Notes:
      * This provider has been deprecated in favor of the `templatefile` function since 2020, now would be a good time to make the swap before it's officially removed.
      * `templatefile` is already used in the OSS repo, so use that a reference
* Deprecation Notice: https://github.com/hashicorp/terraform-provider-template/issues/85
##### hashicorp/random
* Versions:
  * Initial Version: 3.1.0
  * Final Version: 3.5.1
    * Notes:
      * No notable breaking changes or deprecations observed that would affect us
* Change Log: https://github.com/hashicorp/terraform-provider-random/blob/main/CHANGELOG.md
##### hashicorp/null
* Versions:
  * Initial Version: 3.1.0
  * Final Version: 3.2.1
    * Notes:
      * No notable breaking changes or deprecations observed that would affect us
* Change Log: https://github.com/hashicorp/terraform-provider-null/blob/main/CHANGELOG.md
##### hashicorp/external
* Versions:
  * Initial Version: 2.2.2
  * Final Version: 2.3.1
    * Notes:
      * No notable breaking changes or deprecations observed that would affect us
* Change Log: https://github.com/hashicorp/terraform-provider-external/blob/main/CHANGELOG.md
##### hashicorp/time
* Versions:
  * Initial Version: 0.8.0
  * Final Version: 0.9.1
    * Notes:
      * No notable breaking changes or deprecations observed that would affect us
* Change Log: https://github.com/hashicorp/terraform-provider-time/blob/main/CHANGELOG.md


#### Modules
##### module.gke
* Source: terraform-google-modules/kubernetes-engine/google//modules/private-cluster
* Versions:
  * Initial Version: 23.1.0
  * Final Version: 25.0.0
    * Notes:
      * enable auto repair and upgrade with cluster autoscaling [#1530](https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/issues/1530)
        * Small update will need to be made to the `cluster_autoscaling` [line here in main.tf](https://github.com/sassoftware/viya4-iac-gcp/blob/main/main.tf#L123). It now requires the attributes `auto_repair` & `auto_upgrade` and their values, similarly to how we added a default for `gpu_resources` during the [last module update](https://github.com/sassoftware/viya4-iac-gcp/commit/99a33e643f05f16831821679163e45a5113ea194#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbbR115)
        * The default of these additions should be either true or false. We actually set those values in the node_pools map already based off whether the user set `var.kubernetes_channel` [here](https://github.com/sassoftware/viya4-iac-gcp/blob/6d191cff28beb3323787f6b5c98850094f24597e/main.tf#L148-L149), so we can adopt the same behavior for `cluster_autoscaling`
* Change Log: https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/blob/v25.0.0/CHANGELOG.md
##### module.postgresql
* Source: GoogleCloudPlatform/sql-db/google//modules/postgresql
* Versions:
  * Initial Version: 12.0.0
  * Final Version: 15.0.0
    * Notes:
      * from 13.0.0 - deps: update terraform null to ~> 3.2.0
      * from 14.0.0 - Requires Terraform >= 1.3.0
* Change Log: https://github.com/terraform-google-modules/terraform-google-sql-db/blob/master/CHANGELOG.md
##### module.sql_proxy_sa
* Source: terraform-google-modules/service-accounts/google
* Versions:
  * Initial Version: 4.1.1
  * Final Version: 4.2.1
    * Notes:
      * No notable breaking changes or deprecations observed that would affect us
* Change Log: https://github.com/terraform-google-modules/terraform-google-service-accounts/blob/master/CHANGELOG.md
##### module.nat_address
* Source: terraform-google-modules/address/google
* Versions:
  * Initial Version: 3.1.1
  * Final Version: 3.1.2
    * Notes:
      * No notable breaking changes or deprecations observed that would affect us
* Change Log: https://github.com/terraform-google-modules/terraform-google-address/blob/master/CHANGELOG.md
##### module.cloud_nat
* Source: terraform-google-modules/cloud-nat/google
* Versions:
  * Initial Version: 2.2.1
  * Final Version: 3.0.0
    * Notes:
      * from 3.0.0 - Increased minimum Google Provider version to 4.51
* Change Log: https://github.com/terraform-google-modules/terraform-google-cloud-nat/blob/master/CHANGELOG.md

As part of updating the modules we are also going to set
```
  user_deletion_policy     = "ABANDON"
  database_deletion_policy = "ABANDON"
```
When creating a postgres instances so we will no longer be blocked by pgadmin & the SharedServices database when trying to delete the Postgres resource.
Fixes https://github.com/sassoftware/viya4-iac-gcp/issues/47

### Tests

See internal ticket for additional details and security report.


| Scenario | Provider | commit  | kubernetes_version      | Deployment Method | Order  | Cadance   | Notes                                                                                                                                            |
| -------- | -------- | ------- | ----------------------- | ----------------- | ------ | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
| 1        | GCP      | 6ec6b01 | 1.26 (v1.26.3-gke.1000) | Docker            | ****** | fast:2020 | external postgres                                                                                                                                |
| 2        | GCP      | d18955d | 1.25 (v1.25.9-gke.400)  | Docker            | ******| fast:2020 | external postgres, rebase retest & verify jump user-data                                                                                         |
| 3        | GCP      | 6186aaf | 1.25 (v1.25.9-gke.400)  | Docker            | ******| fast:2020 | external postgres verify updated DB deletion, enable_cluster_autoscaling verify auto-provisioning values,  create_nfs_public_ip verify user-data |
| 4        | GCP      | 6186aaf | 1.26 (v1.26.4-gke.500)  | Docker            | ******| fast:2020 | internal postgres                                                                                                                                |
| 5        | GCP      | fc09007 | 1.26 (v1.26.4-gke.500)  | Docker            | ******| fast:2020 | external postgres                                                                                                                                |
| 6        | GCP      | 5eb5078 | 1.26 (v1.26.4-gke.500)  | Docker            | ******| fast:2020 | external postgres                                                                                                                                |