### PR TITLE
feat!: (IAC-970) Update Terraform Version to 1.4.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright © 2021-2023, SAS Institute Inc., Cary, NC, USA. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-ARG TERRAFORM_VERSION=1.0.0
+ARG TERRAFORM_VERSION=1.4.5
 ARG GCP_CLI_VERSION=428.0.0
 FROM hashicorp/terraform:$TERRAFORM_VERSION as terraform
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Operational knowledge of
 
 - Terraform or Docker
   - #### Terraform
-    - [Terraform](https://www.terraform.io/downloads.html) - v1.0.0
+    - [Terraform](https://www.terraform.io/downloads.html) - v1.4.5
     - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl) - v1.25.8
     - [jq](https://stedolan.github.io/jq/) - v1.6
     - [gcloud CLI](https://cloud.google.com/sdk/gcloud) - (optional - useful as an alternative to the Google Cloud Platform Portal) - v428.0.0

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 terraform {
-  required_version = ">= 1.0.0"
+  required_version = ">= 1.4.5"
 
   required_providers {
     google = {


### PR DESCRIPTION
### Changes

Updated the default and minimum required Terraform version to 1.4.5, to pull in the latest features, fixes, and security patches from HashiCorp.

Consumers of the Dockerfile will already have the version updated within the installation stages. For users that are running viya4-iac-gcp directly on their machine without the use of the Docker container (by executing the `terraform` command) should update their Terraform version to at least 1.4.5.

**Note** This is the new PR after the revert from earlier.


### Tests
| Scenario | Provider | kubernetes_version      | kubectl version | Deployment Method | Terraform Version | Order  | Cadence   | Notes                               |
| -------- | -------- | ----------------------- | --------------- | ----------------- | ----------------- | ------ | --------- | ----------------------------------- |
| 1        | GCP      | 1.25 (v1.25.8-gke.1000) | 1.25.8          | Docker            | 1.4.5             | ******  | fast:2020 | baseline,viya,install               |
| 2        | GCP      | 1.25 (v1.25.8-gke.1000) | 1.25.4          | Local Terraform   | 1.4.5             | n/a    | n/a       | only tested infrastructure creation |

Additional smoke test after adding this change back in

| Scenario | Provider | kubernetes_version     | kubectl version | Deployment Method | Terraform Version | Order  | Cadence   | Notes                 |
|----------|----------|------------------------|-----------------|-------------------|-------------------|--------|-----------|-----------------------|
| 1        | GCP      | 1.26 (1.26.3-gke.1000) | 1.25.8          | Docker            | 1.4.5             | ****** | fast:2020 | baseline,viya,install |