### PR TITLE
feat: (IAC-895) Add Support to Toggle the Google Cloud Managed Service for Prometheus

### DIFF
--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -20,6 +20,7 @@ Supported configuration variables are listed in the table below.  All variables 
     - [For `storage_type=ha` only (Google Filestore)](#for-storage_typeha-only-google-filestore)
   - [Google Container Registry (GCR)](#google-container-registry-gcr)
   - [Postgres Servers](#postgres-servers)
+  - [Monitoring](#monitoring)
 
 Terraform input variables can be set in the following ways:
 - Individually, with the [-var command line option](https://www.terraform.io/docs/configuration/variables.html#variables-on-the-command-line).
@@ -293,3 +294,9 @@ postgres_servers = {
   }
 }
 ```
+
+## Monitoring
+
+| Name | Description | Type | Default | Notes |
+| :--- | ---: | ---: | ---: | ---: |
+| enable_managed_prometheus | Enable Google Cloud [Managed Service for Prometheus](https://cloud.google.com/stackdriver/docs/managed-prometheus) for your cluster | boolean | false | |

--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -299,4 +299,9 @@ postgres_servers = {
 
 | Name | Description | Type | Default | Notes |
 | :--- | ---: | ---: | ---: | ---: |
+| create_gke_monitoring_service | Enable GKE metrics from pods in the cluster to the Google Cloud Monitoring API | boolean | false | |
+| gke_monitoring_service | Value of the Google Cloud Monitoring API to use if monitoring is enabled. Values are: monitoring.googleapis.com, monitoring.googleapis.com/kubernetes, none | string | "none" | |
+| gke_monitoring_enabled_components | List of services to monitor: SYSTEM_COMPONENTS, WORKLOADS (WORKLOADS deprecated in 1.24). | list of strings | ["SYSTEM_COMPONENTS"] | |
 | enable_managed_prometheus | Enable Google Cloud [Managed Service for Prometheus](https://cloud.google.com/stackdriver/docs/managed-prometheus) for your cluster | boolean | false | |
+
+Note: For additional details about Google Kubernetes Engine (GKE) integration with Cloud Logging and Cloud Monitoring, including Google Cloud [Managed Service for Prometheus](https://cloud.google.com/stackdriver/docs/managed-prometheus), view the ["Overview of Google Cloud's operations suite for GKE" documentation](https://cloud.google.com/stackdriver/docs/solutions/gke) 

--- a/main.tf
+++ b/main.tf
@@ -123,6 +123,8 @@ module "gke" {
 
   monitoring_service = var.create_gke_monitoring_service ? var.gke_monitoring_service : "none"
 
+  monitoring_enable_managed_prometheus = var.enable_managed_prometheus
+
   cluster_autoscaling = var.enable_cluster_autoscaling ? {
     enabled : true,
     max_cpu_cores : var.cluster_autoscaling_max_cpu_cores,

--- a/main.tf
+++ b/main.tf
@@ -122,6 +122,7 @@ module "gke" {
   grant_registry_access = var.enable_registry_access
 
   monitoring_service = var.create_gke_monitoring_service ? var.gke_monitoring_service : "none"
+  monitoring_enabled_components = var.create_gke_monitoring_service ? var.gke_monitoring_enabled_components : []
 
   monitoring_enable_managed_prometheus = var.enable_managed_prometheus
 

--- a/variables.tf
+++ b/variables.tf
@@ -389,10 +389,16 @@ variable "gke_monitoring_service" {
   default     = "none"
 }
 
+variable "gke_monitoring_enabled_components" {
+  type        = list(string)
+  description = "List of services to monitor: SYSTEM_COMPONENTS, WORKLOADS (WORKLOADS deprecated in 1.24)."
+  default     = ["SYSTEM_COMPONENTS"]
+}
+
 variable "enable_managed_prometheus" {
   type        = bool
   description = "Enable Google Cloud Managed Service for Prometheus for your cluster"
-  default     = "false"
+  default     = false
 }
 
 # Network

--- a/variables.tf
+++ b/variables.tf
@@ -376,7 +376,7 @@ variable "enable_registry_access" {
   default     = true
 }
 
-# Azure Monitor
+# GKE Monitoring
 variable "create_gke_monitoring_service" {
   type        = bool
   description = "Enable GKE metrics from pods in the cluster to the Google Cloud Monitoring API."
@@ -387,6 +387,12 @@ variable "gke_monitoring_service" {
   type        = string
   description = "Value of the Google Cloud Monitoring API to use if monitoring is enabled. Values are: monitoring.googleapis.com, monitoring.googleapis.com/kubernetes, none"
   default     = "none"
+}
+
+variable "enable_managed_prometheus" {
+  type        = bool
+  description = "Enable Google Cloud Managed Service for Prometheus for your cluster"
+  default     = "false"
 }
 
 # Network


### PR DESCRIPTION
### Changes

After March 15, 2023 all newly created Google Kubernetes Engine standard clusters will have [Managed Service for Prometheus](https://cloud.google.com/stackdriver/docs/managed-prometheus) in-cluster components deployed by default.

This default enabled feature from Google does add a small amount of cost. See https://cloud.google.com/stackdriver/pricing#mgd-prometheus-pricing-summary

In order to support users who do want this service in their cluster by default we are adding the `enable_managed_prometheus` to control the deployment of the  "Managed Service for Prometheus" in their clusters. By default we are setting this value to false.

Note: Google has still not enabled this feature by default, but adding the flag as a feature in case users want to enable this themselves.

### Tests

| Scenario | Provider | Kubernetes Version     | Deployment Method | `enable_managed_prometheus` | Notes                              |
|----------|----------|------------------------|-------------------|---------------------------|------------------------------------|
| 1        | GCP      | 1.26 (v1.26.4-gke.500) | Docker            | true                      | GMP was present in the cluster     |
| 2        | GCP      | 1.26 (v1.26.4-gke.500  | Docker            | unset (default false)     | GMP was NOT present in the cluster |


Additional tests after review comments:

### Tests

| Scenario | Provider | Kubernetes Version     | Deployment Method | enable_managed_prometheus | create_gke_monitoring_service | gke_monitoring_service               | gke_monitoring_enabled_components     | Notes                                                      |
|----------|----------|------------------------|-------------------|---------------------------|-------------------------------|--------------------------------------|---------------------------------------|------------------------------------------------------------|
| 3        | GCP      | 1.26 (v1.26.4-gke.500) | Docker            | true                      | true                          | monitoring.googleapis.com/kubernetes | unset (default ["SYSTEM_COMPONENTS"]) | GMP was present in the cluster & gke-metrics-agent present |
| 4        | GCP      | 1.26 (v1.26.4-gke.500) | Docker            | true                      | false                         | unset (default none n/a)             | unset n/a                             | GMP was present in the cluster gke-metrics-agent absent    |
