### PR TITLE
doc: Document that Permissions to GAR are also granted.

### DIFF
--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -18,7 +18,7 @@ Supported configuration variables are listed in the table below.  All variables 
   - [Storage](#storage)
     - [For `storage_type=standard` only (NFS server VM)](#for-storage_typestandard-only-nfs-server-vm)
     - [For `storage_type=ha` only (Google Filestore)](#for-storage_typeha-only-google-filestore)
-  - [Google Container Registry (GCR)](#google-container-registry-gcr)
+  - [Google Artifact Registry (GAR) and Google Container Registry (GCR)](#google-artifact-registry-gar-and-google-container-registry-gcr)
   - [Postgres Servers](#postgres-servers)
   - [Monitoring](#monitoring)
 
@@ -227,12 +227,11 @@ stateful = {
 | filestore_tier | The service tier for the Google Filestore Instance | string | "BASIC_HDD" | Valid Values: "BASIC_HDD", "BASIC_SSD" (previously called "STANDARD" and "PREMIUM" respectively.)  |
 | filestore_size_in_gb | Size in GB of Filesystem in the Google Filestore Instance | number | 1024 for BASIC_HDD, 2560 for BASIC_SDD | 2560 GB is the minimum size for the BASIC_SSD tier. The BASIC_HDD tier allows a minimum size of 1024 GB. |
 
-## Google Container Registry (GCR)
+## Google Artifact Registry (GAR) and Google Container Registry (GCR)
 
 | Name | Description | Type | Default | Notes |
 | :--- | ---: | ---: | ---: | ---: |
-| enable_registry_access | Enable access from the GKE Cluster to the GCR for your Google Project | bool | true | adds the "Artifact Registry Reader" and "Storage Object Viewer" Roles to the Service Account associated with the Node VMs. |
-
+| enable_registry_access | Enable access from the GKE Cluster to the GAR and GCR for your Google Project | bool | true | adds the "Artifact Registry Reader" and "Storage Object Viewer" Roles to the Service Account associated with the Node VMs. |
 
 
 ## Postgres Servers

--- a/docs/user/APIServices.md
+++ b/docs/user/APIServices.md
@@ -11,5 +11,6 @@ Make sure your Google Cloud Project has at least the following API Services enab
 | `servicenetworking.googleapis.com`| [Service Networking API](https://console.cloud.google.com/apis/library/servicenetworking.googleapis.com) | Needed when creating an [SQL Postgres instance](../CONFIG-VARS.md#postgres-servers) |
 | `cloudresourcemanager.googleapis.com`| [Cloud Resource Manager API](https://console.cloud.google.com/apis/library/cloudresourcemanager.googleapis.com) | Needed if you create an [SQL Postgres instance](../CONFIG-VARS.md#postgres-servers) |
 | `containerregistry.googleapis.com` | [Google Container Registry](https://console.cloud.google.com/apis/library/containerregistry.googleapis.com) | Needed when using GCR to store and access deployment artifacts |
+| `artifactregistry.googleapis.com` | [Google Artifact Registry](https://console.cloud.google.com/apis/library/artifactregistry.googleapis.com) | Needed when using GAR to store and access deployment artifacts |
 
 Further detail on [enabling API Services](https://cloud.google.com/apis/docs/getting-started#enabling_apis).


### PR DESCRIPTION
### Changes
No functionality changes, just want to document that the existing flag `enable_registry_access` also already grants `Artifact Registry Reader` roles which allows the cluster to pull from the Artifact Registry which Google recommends over the now deprecated Container Registry.

Both will still work at this time: https://cloud.google.com/container-registry/docs/deprecations/container-registry-deprecation

### Tests

| Provider | K8s Version      | enable_registry_access | Cadence   | Order  | V4_CFG_CR_USER    | V4_CFG_CR_PASSWORD                | V4_CFG_CR_URL                           | Notes                        |
|----------|------------------|------------------------|-----------|--------|-------------------|-----------------------------------|-----------------------------------------|------------------------------|
| GCP      | v1.26.5-gke.1400 | TRUE                   | fast:2020 | ****** | oauth2accesstoken | $(gcloud auth print-access-token) | us-east1-docker.pkg.dev/$PROJECT/jarpat | Mirror was successfully used |