### PR TITLE
docs: (IAC-977) Update enable_cluster_autoscaling documentation

### DIFF
--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -104,7 +104,7 @@ The application of a Kubernetes version in GCP has some limitations when assigni
 | :--- | ---: | ---: | ---: | ---: |
 | kubernetes_version | The GKE cluster K8S version | string | "latest" | Valid values depend on the kubernetes_channel and version required, see https://cloud.google.com/kubernetes-engine/docs/release-notes |
 | kubernetes_channel | The GKE cluster channel for auto-updates | string | "UNSPECIFIED" | Possible values: "STABLE", "REGULAR", "RAPID"; Set "UNSPECIFIED" for no auto-updates |
-| enable_cluster_autoscaling | Enable cluster autoscaling | bool | false | |
+| enable_cluster_autoscaling | Per-cluster configuration of [Node Auto-Provisioning](https://cloud.google.com/kubernetes-engine/docs/how-to/node-auto-provisioning) with Cluster Autoscaler to automatically adjust the size of the cluster and create/delete node pools based on the current needs of the cluster's workload | bool | false | This is different from node autoscaling which is controlled by `max_node` & `min_node` in your [node pool definitions](#Nodepools)|
 | cluster_autoscaling_max_cpu_cores | MAX number of cores in the cluster | number | 500 | |
 | cluster_autoscaling_max_memory_gb | MAX number of gb of memory in the cluster | number | 10000 | |
 | create_static_kubeconfig | Allows the user to create a provider / service account based kube config file | bool | true | A value of `false` will default to using the cloud providers mechanism for generating the kubeconfig file. A value of `true` will create a static kubeconfig which utilizes a `Service Account` and `Cluster Role Binding` to provide credentials. |

--- a/variables.tf
+++ b/variables.tf
@@ -242,7 +242,7 @@ variable "default_nodepool_locations" {
 
 variable "node_pools" {
   description = "Node pool definitions"
-  type = map(object({
+  type        = map(object({
     vm_type           = string
     os_disk_size      = number
     min_nodes         = string
@@ -260,7 +260,7 @@ variable "node_pools" {
       "min_nodes"    = 1
       "max_nodes"    = 5
       "node_taints"  = ["workload.sas.com/class=cas:NoSchedule"]
-      "node_labels" = {
+      "node_labels"  = {
         "workload.sas.com/class" = "cas"
       }
       "local_ssd_count"   = 0
@@ -273,7 +273,7 @@ variable "node_pools" {
       "min_nodes"    = 1
       "max_nodes"    = 5
       "node_taints"  = ["workload.sas.com/class=compute:NoSchedule"]
-      "node_labels" = {
+      "node_labels"  = {
         "workload.sas.com/class"        = "compute"
         "launcher.sas.com/prepullImage" = "sas-programming-environment"
       }
@@ -287,7 +287,7 @@ variable "node_pools" {
       "min_nodes"    = 1
       "max_nodes"    = 5
       "node_taints"  = ["workload.sas.com/class=stateless:NoSchedule"]
-      "node_labels" = {
+      "node_labels"  = {
         "workload.sas.com/class" = "stateless"
       }
       "local_ssd_count"   = 0
@@ -300,7 +300,7 @@ variable "node_pools" {
       "min_nodes"    = 1
       "max_nodes"    = 3
       "node_taints"  = ["workload.sas.com/class=stateful:NoSchedule"]
-      "node_labels" = {
+      "node_labels"  = {
         "workload.sas.com/class" = "stateful"
       }
       "local_ssd_count"   = 0
@@ -327,7 +327,7 @@ variable "nodepools_locations" {
 }
 
 variable "enable_cluster_autoscaling" {
-  description = "Setting this value will enable cluster_autoscaling"
+  description = "Setting this value will enable cluster_autoscaling a per-cluster configuration of Node Auto-Provisioning with Cluster Autoscaler to automatically adjust the size of the cluster and create/delete node pools based on the current needs of the cluster's workload."
   type        = bool
   default     = false
 }
@@ -350,7 +350,7 @@ variable "cluster_autoscaling_max_memory_gb" {
 variable "postgres_server_defaults" {
   description = "default values for a postgres server"
   type        = any
-  default = {
+  default     = {
     machine_type                           = "db-custom-8-30720"
     storage_gb                             = 10
     backups_enabled                        = true


### PR DESCRIPTION
### Changes
Update the documentation for the `enable_cluster_autoscaling` variable to make it more clear to the user what it does.

The scaling of nodes within node pools (e.g. additional stateful or cas nodes) is what someone typically thinks of when reading the word autoscaling and the limits are controlled by the existing `min_nodes` & `max_nodes` variables when configuring the node_pool map within your terraform.tfvars See: https://github.com/sassoftware/viya4-iac-gcp/blob/main/docs/CONFIG-VARS.md#additional-nodepools

The `enable_cluster_autoscaling` variable configures the creation of additional **new** node pools when resources requests are made and no existing node pools or nodes can satisfy the request. In our Terraform code the variable is exposed to the user as `enable_cluster_autoscaling` which is passed to the official GKE terraform module and referred to as `cluster_autoscaling`. Even though the variable configures node auto provisioning, the naming from Google is a little confusing. As a side note, even in the web GCP console when we enable cluster_autoscaling via terraform it toggles the  "Node auto-provisioning" setting in the UI.

Provider Doc: https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster#cluster_autoscaling
GCP Doc: https://cloud.google.com/kubernetes-engine/docs/concepts/cluster-autoscaler
