### PR TITLE
fix: (IAC-1091) Prevent Jump VM cloud-init from overwriting existing file permissions/ownership

### DIFF
--- a/files/cloud-init/jump/cloud-config
+++ b/files/cloud-init/jump/cloud-config
@@ -31,10 +31,14 @@ runcmd:
       # mount the nfs
       #
   -   while [ `df -h | grep "${rwx_filestore_endpoint}:${rwx_filestore_path}" | wc -l` -eq 0 ]; do sleep 5 && mount -a ; done
-      #
-      # Change permissions and owner
-      #
-  -   mkdir -p ${jump_rwx_filestore_path}/pvs
-  -   $(chmod -fR 777 ${jump_rwx_filestore_path} ; echo)
-  -   $(chown -R nobody:nogroup ${jump_rwx_filestore_path} ; echo)
+      # Create pvs folder and adjust perms and owner only if the folder doesn't exist
+  -   if ! [ -d "${jump_rwx_filestore_path}/pvs" ]
+  -   then
+        #
+        # Change permissions and owner
+        #
+  -     mkdir -p ${jump_rwx_filestore_path}/pvs
+  -     $(chmod -fR 777 ${jump_rwx_filestore_path} ; echo)
+  -     $(chown -R nobody:nogroup ${jump_rwx_filestore_path} ; echo)
+  -   fi
   - fi

--- a/files/cloud-init/jump/cloud-config
+++ b/files/cloud-init/jump/cloud-config
@@ -32,6 +32,8 @@ runcmd:
       #
   -   while [ `df -h | grep "${rwx_filestore_endpoint}:${rwx_filestore_path}" | wc -l` -eq 0 ]; do sleep 5 && mount -a ; done
       # Create pvs folder and adjust perms and owner only if the folder doesn't exist
+      # On subsequent jump server creation if the mounted NFS already contains a "pvs" directory
+      # don't overwrite ownerships and permissions set by SAS Viya
   -   if ! [ -d "${jump_rwx_filestore_path}/pvs" ]
   -   then
         #


### PR DESCRIPTION
### Changes:
When a new jump server vm is created, it sets file ownership and permissions for the mounted NFS location which allows Viya services to initialize successfully. Importantly, the file system settings should only be applied once and not repeatedly in the event that the jump vm is destroyed and recreated in the same cluster. This change checks if the `${jump_rwx_filestore_path}/pvs` folder already exists and skips creating the folder and recursively setting ownerships and permissions if it does. If the jump vm is being created for the first time when the pvs folder is absent, creating the folder and setting permissions and ownership will occur an initial time and not thereafter.


### Tests:
Executed the following workflow to verify that file permissions and ownership was not modified on Jump VM recreation

#### Steps:
 - Created cluster using viya4-iac-gcp
 - Verify infrastructure created successfully
   - Checked initial permissions and ownership of files of mounted files system on Jump VM
 - Deploy Viya4 using DaC
 - Verify Viya deployment is stabilized 
   - Checked permissions and ownership of files mounted on the Jump VM that were created by the Viya deployment
 - Stop Viya. [Stop a SAS Viya Platform Deployment](https://go.documentation.sas.com/doc/en/itopscdc/v_040/itopssrv/n0pwhguy22yhe0n1d7pgi63mf6pb.htm#p05jsfcz54bsejn1x1r34f0zrag6)
 - Verify all pods are terminated
 - Replace jump server vm using terraform replace command (Alternative to destroy and create), verified that the existing jump vm is destroyed and a new one is created.
 - Start Viya [Start a SAS Viya Platform Deployment](https://go.documentation.sas.com/doc/en/itopscdc/v_040/itopssrv/n0pwhguy22yhe0n1d7pgi63mf6pb.htm#p05jsfcz54bsejn1x1r34f0zrag6)
 - Check deployment/pods status verify all Viya pods, services and applications stabilize and are accessible. 
   - Checked that permissions and ownership of files mounted on the Jump VM that were created by the Viya deployment were not changed upon the rerun of the cloud init script.