### PR TITLE
feat: (IAC-1097) Update Google Cloud CLI to 440.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ARG TERRAFORM_VERSION=1.4.5
-ARG GCP_CLI_VERSION=428.0.0
+ARG GCP_CLI_VERSION=440.0.0
 
 FROM hashicorp/terraform:$TERRAFORM_VERSION as terraform
 FROM google/cloud-sdk:$GCP_CLI_VERSION-alpine

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Operational knowledge of
     - [Terraform](https://www.terraform.io/downloads.html) - v1.4.5
     - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl) - v1.25.8
     - [jq](https://stedolan.github.io/jq/) - v1.6
-    - [gcloud CLI](https://cloud.google.com/sdk/gcloud) - (optional - useful as an alternative to the Google Cloud Platform Portal) - v428.0.0
+    - [gcloud CLI](https://cloud.google.com/sdk/gcloud) - (optional - useful as an alternative to the Google Cloud Platform Portal) - v440.0.0
     - [gke-gcloud-auth-plugin](https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-access-for-kubectl#install_plugin) - (optional - only for provider based Kubernetes configuration files) - >= v1.26
   - #### Docker
     - [Docker](https://docs.docker.com/get-docker/)


### PR DESCRIPTION
### Changes

Updates the Google Cloud CLI to 440.0.0 to pick up the latest updates

In viya4-iac-gcp since the CLI is delivered via the `google/cloud-sdk:440.0.0-alpine` base image we also get updated to Alpine 3.18.2 in the image which patches some security issues.

### Tests

| Scenario | Provider | gcloud version | K8s Version      | Kubeconfig  | Orchestration | Order  | Cadence        |
|----------|----------|----------------|------------------|-------------|---------------|--------|----------------|
| 1        | GCP      | 440.0.0        | v1.26.5-gke.2700 | static      | DO            | * | fast:2020      |
| 2        | GCP      | 440.0.0        | v1.26.5-gke.2700 | auth plugin | DO            | * | stable:2023.07 |