### PR TITLE
feat: (IAC-1022) Increase the Default IP Range for database_subnet_cidr

### DIFF
--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -68,7 +68,7 @@ You can use `default_public_access_cidrs` to set a default range for all created
 | gke_control_plane_subnet_cidr |  Address space for the hosted master subnet | string | "10.2.0.0/28" | When providing your own subnets (by setting `subnet_names` make sure your subnets do not overlap this range  |
 | misc_subnet_cidr | Address space for the the auxiliary resources (Jump VM and optionally NFS VM) subnet | string | "192.168.2.0/24" | This variable is ignored when `subnet_names` is set (aka bring your own subnet) |
 | filestore_subnet_cidr | Address space for Google Filestore subnet | string | "192.168.3.0/29" | Needs to be at least a /29 range. Only used when `storage_type="ha"` |
-| database_subnet_cidr | Address space for Google Cloud SQL Postgres subnet | string | "192.168.4.0/24" | Only used with external postgres |
+| database_subnet_cidr | Address space for Google Cloud SQL Postgres subnet | string | "192.168.4.0/23" | Only used with external postgres |
 
 ### Use Existing
 

--- a/variables.tf
+++ b/variables.tf
@@ -510,7 +510,7 @@ variable "filestore_subnet_cidr" {
 variable "database_subnet_cidr" {
   description = "Address space for Google Cloud SQL Postgres subnet"
   type        = string
-  default     = "192.168.4.0/24"
+  default     = "192.168.4.0/23"
 }
 
 


### PR DESCRIPTION
### Changes

Increases the default IP range for `database_subnet_cidr` from  `192.168.4.0/24` to  `192.168.4.0/23`. This is to mitigate an issue that some users were experiencing when provisioning 2+ Cloud SQL instances as part of the GCP IAC process, In some cases users would see an error that looks like: `Failed to create subnetwork. Couldn't find free blocks in allocated IP ranges. Please allocate new ranges for this service provider`. The recommendation from a Google support ticket was to increase the size of `database_subnet_cidr`. 


GCP: Private IP Documentation: https://cloud.google.com/sql/docs/mysql/private-ip#allocated_range_size

### Tests


| Scenario | Provider | Cloud SQL Instances | K8s Version     | Order  | Cadence   | Notes                                                                                                                                                                                                                                  |
|----------|----------|---------------------|-----------------|--------|-----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| 1        | GCP      | 2                   | v1.26.7-gke.500 | ****** | fast:2020 | included risk to test out cds-postgres                                                                                                                                                                                                 |
| 2        | GCP      | 1                   | v1.26.7-gke.500 | n/a    | n/a       |                                                                                                                                                                                                                                        |
| 3        | GCP      | 4                   | v1.26.7-gke.500 | n/a    | n/a       |                                                                                                                                                                                                                                        |
| 4        | GCP      | 2                   | v1.26.7-gke.500 | ****** | fast:2020 | initial deployment with 5.4.0 so that the subnet was `192.168.4.0/24`, stopped viya and reapplied with PR code so subnet updated to  `192.168.4.0/23` started Viya and ensured it was still able to connect to the Cloud SQL instances |