### PR TITLE
chore: (IAC-1195) Update Branch Selector for GitHub Workflow

### DIFF
--- a/.github/workflows/linter-analysis.yaml
+++ b/.github/workflows/linter-analysis.yaml
@@ -1,7 +1,7 @@
 name: Linter Analysis
 on:
   push:
-    branches: [ '*' ] # '*' will cause the workflow to run on all commits to all branches.
+    branches: [ '**' ] # '**' will cause the workflow to run on all commits to all branches, including those with path separators
 
 jobs:
   # Hadolint: Job-1


### PR DESCRIPTION
### Changes
Update the branch selector for the GitHub workflow to allow it to additionally run against branches that use the [path pattern](https://docs.github.com/en/get-started/using-git/dealing-with-special-characters-in-branch-and-tag-names#about-branch-and-tag-names) (e.g. "fix/IAC-111").


### Tests

The name of the source branch of this PR uses the path pattern `chore/IAC-1195` and the GitHub workflow was automatically run.