### PR TITLE
chore: (IAC-1230) Resolve Linting Warning

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -51,13 +51,13 @@ resource "kubernetes_config_map" "sas_iac_buildinfo" {
   }
 
   data = {
-    git-hash    = lookup(data.external.git_hash[0].result, "git-hash")
+    git-hash    = data.external.git_hash[0].result["git-hash"]
     iac-tooling = var.iac_tooling
     terraform   = <<EOT
-version: ${lookup(data.external.iac_tooling_version[0].result, "terraform_version")}
-revision: ${lookup(data.external.iac_tooling_version[0].result, "terraform_revision")}
-provider-selections: ${lookup(data.external.iac_tooling_version[0].result, "provider_selections")}
-outdated: ${lookup(data.external.iac_tooling_version[0].result, "terraform_outdated")}
+version: ${data.external.iac_tooling_version[0].result["terraform_version"]}
+revision: ${data.external.iac_tooling_version[0].result["terraform_revision"]}
+provider-selections: ${data.external.iac_tooling_version[0].result["provider_selections"]}
+outdated: ${data.external.iac_tooling_version[0].result["terraform_outdated"]}
 EOT
   }
 


### PR DESCRIPTION
### Changes
Update the code to resolve `terraform_deprecated_lookup` linting issues 

doc: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.5.0/docs/rules/terraform_deprecated_lookup.md

### Tests

Created infrastructure and ensured the `sas-iac-buildinfo` was present

```
$ kubectl get cm -n kube-system sas-iac-buildinfo -o yaml
apiVersion: v1
data:
  git-hash: 1fc00df6e7bc14d261f71fa475e1cc887533adfe
  iac-tooling: terraform
  terraform: |
    version: "1.6.3"
    revision: null
    provider-selections: {"registry.terraform.io/hashicorp/external":"2.3.1","registry.terraform.io/hashicorp/google":"4.63.1","registry.terraform.io/hashicorp/google-beta":"4.63.1","registry.terraform.io/hashicorp/kubernetes":"2.20.0","registry.terraform.io/hashicorp/local":"2.4.0","registry.terraform.io/hashicorp/null":"3.2.1","registry.terraform.io/hashicorp/random":"3.5.1","registry.terraform.io/hashicorp/time":"0.9.1"}
    outdated: false
immutable: false
kind: ConfigMap
metadata:
  creationTimestamp: "2023-11-16T16:29:58Z"
  name: sas-iac-buildinfo
  namespace: kube-system
  resourceVersion: "2711"
  uid: 0566a6f3-d833-4113-9bbe-17f4086d7af8
```