### PR TITLE
feat: (IAC-1312) Update Dependencies to Resolve Security Warnings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # Copyright © 2021-2023, SAS Institute Inc., Cary, NC, USA. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-ARG TERRAFORM_VERSION=1.4.5
-ARG GCP_CLI_VERSION=440.0.0
+ARG TERRAFORM_VERSION=1.7.0
+ARG GCP_CLI_VERSION=460.0.0
 
 FROM hashicorp/terraform:$TERRAFORM_VERSION as terraform
 FROM google/cloud-sdk:$GCP_CLI_VERSION-alpine

--- a/README.md
+++ b/README.md
@@ -31,10 +31,10 @@ Operational knowledge of
 
 - Terraform or Docker
   - #### Terraform
-    - [Terraform](https://www.terraform.io/downloads.html) - v1.4.5
+    - [Terraform](https://www.terraform.io/downloads.html) - v1.7.0
     - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl) - v1.27.8
     - [jq](https://stedolan.github.io/jq/) - v1.6
-    - [gcloud CLI](https://cloud.google.com/sdk/gcloud) - (optional - useful as an alternative to the Google Cloud Platform Portal) - v440.0.0
+    - [gcloud CLI](https://cloud.google.com/sdk/gcloud) - (optional - useful as an alternative to the Google Cloud Platform Portal) - v460.0.0
     - [gke-gcloud-auth-plugin](https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-access-for-kubectl#install_plugin) - (optional - only for provider based Kubernetes configuration files) - >= v1.26
   - #### Docker
     - [Docker](https://docs.docker.com/get-docker/)

--- a/main.tf
+++ b/main.tf
@@ -91,7 +91,7 @@ data "google_container_engine_versions" "gke-version" {
 
 module "gke" {
   source                        = "terraform-google-modules/kubernetes-engine/google//modules/private-cluster"
-  version                       = "25.0.0"
+  version                       = "29.0.0"
   project_id                    = var.project
   name                          = "${var.prefix}-gke"
   region                        = local.region
@@ -125,6 +125,9 @@ module "gke" {
   monitoring_enabled_components = var.create_gke_monitoring_service ? var.gke_monitoring_enabled_components : []
 
   monitoring_enable_managed_prometheus = var.enable_managed_prometheus
+
+  # allows the cluster to be deleted by TF
+  deletion_protection = false
 
   cluster_autoscaling = var.enable_cluster_autoscaling ? {
     enabled : true,
@@ -236,7 +239,7 @@ resource "local_file" "kubeconfig" {
 # Module Registry - https://registry.terraform.io/modules/GoogleCloudPlatform/sql-db/google/12.0.0/submodules/postgresql
 module "postgresql" {
   source     = "GoogleCloudPlatform/sql-db/google//modules/postgresql"
-  version    = "15.0.0"
+  version    = "18.2.0"
   project_id = var.project
 
   for_each = local.postgres_servers != null ? length(local.postgres_servers) != 0 ? local.postgres_servers : {} : {}
@@ -288,7 +291,7 @@ module "postgresql" {
 
 module "sql_proxy_sa" {
   source        = "terraform-google-modules/service-accounts/google"
-  version       = "4.2.1"
+  version       = "4.2.2"
   count         = var.postgres_servers != null ? length(var.postgres_servers) != 0 ? 1 : 0 : 0
   project_id    = var.project
   prefix        = var.prefix

--- a/main.tf
+++ b/main.tf
@@ -91,7 +91,7 @@ data "google_container_engine_versions" "gke-version" {
 
 module "gke" {
   source                        = "terraform-google-modules/kubernetes-engine/google//modules/private-cluster"
-  version                       = "29.0.0"
+  version                       = "~> 29.0.0"
   project_id                    = var.project
   name                          = "${var.prefix}-gke"
   region                        = local.region
@@ -239,7 +239,7 @@ resource "local_file" "kubeconfig" {
 # Module Registry - https://registry.terraform.io/modules/GoogleCloudPlatform/sql-db/google/12.0.0/submodules/postgresql
 module "postgresql" {
   source     = "GoogleCloudPlatform/sql-db/google//modules/postgresql"
-  version    = "18.2.0"
+  version    = "~> 18.2.0"
   project_id = var.project
 
   for_each = local.postgres_servers != null ? length(local.postgres_servers) != 0 ? local.postgres_servers : {} : {}
@@ -291,7 +291,7 @@ module "postgresql" {
 
 module "sql_proxy_sa" {
   source        = "terraform-google-modules/service-accounts/google"
-  version       = "4.2.2"
+  version       = "~> 4.2.2"
   count         = var.postgres_servers != null ? length(var.postgres_servers) != 0 ? 1 : 0 : 0
   project_id    = var.project
   prefix        = var.prefix

--- a/modules/google_vm/main.tf
+++ b/modules/google_vm/main.tf
@@ -3,7 +3,7 @@
 
 module "address" {
   source       = "terraform-google-modules/address/google"
-  version      = "3.1.2"
+  version      = "3.2.0"
   project_id   = var.project
   region       = var.region
   address_type = "EXTERNAL"

--- a/modules/google_vm/main.tf
+++ b/modules/google_vm/main.tf
@@ -3,7 +3,7 @@
 
 module "address" {
   source       = "terraform-google-modules/address/google"
-  version      = "3.2.0"
+  version      = "~> 3.2.0"
   project_id   = var.project
   region       = var.region
   address_type = "EXTERNAL"

--- a/network.tf
+++ b/network.tf
@@ -11,7 +11,7 @@ data "google_compute_address" "nat_address" {
 module "nat_address" {
   count        = length(var.nat_address_name) == 0 ? 1 : 0
   source       = "terraform-google-modules/address/google"
-  version      = "3.2.0"
+  version      = "~> 3.2.0"
   project_id   = var.project
   region       = local.region
   address_type = "EXTERNAL"
@@ -23,7 +23,7 @@ module "nat_address" {
 module "cloud_nat" {
   count         = length(var.nat_address_name) == 0 ? 1 : 0
   source        = "terraform-google-modules/cloud-nat/google"
-  version       = "5.0.0"
+  version       = "~> 5.0.0"
   project_id    = var.project
   name          = "${var.prefix}-cloud-nat"
   region        = local.region

--- a/network.tf
+++ b/network.tf
@@ -68,6 +68,11 @@ resource "google_service_networking_connection" "private_vpc_connection" {
   network                 = module.vpc.network_name
   service                 = "servicenetworking.googleapis.com"
   reserved_peering_ranges = [google_compute_global_address.private_ip_address[0].name]
+
+  # required as of hashicorp/google v5.12.0 when using google_service_networking_connection in
+  # conjunction with CloudSQL instances in order to cleanly delete resources
+  # https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_networking_connection
+  deletion_policy         = "ABANDON"
 }
 
 resource "google_compute_firewall" "nfs_vm_cluster_firewall" {

--- a/network.tf
+++ b/network.tf
@@ -11,7 +11,7 @@ data "google_compute_address" "nat_address" {
 module "nat_address" {
   count        = length(var.nat_address_name) == 0 ? 1 : 0
   source       = "terraform-google-modules/address/google"
-  version      = "3.1.2"
+  version      = "3.2.0"
   project_id   = var.project
   region       = local.region
   address_type = "EXTERNAL"
@@ -23,7 +23,7 @@ module "nat_address" {
 module "cloud_nat" {
   count         = length(var.nat_address_name) == 0 ? 1 : 0
   source        = "terraform-google-modules/cloud-nat/google"
-  version       = "3.0.0"
+  version       = "5.0.0"
   project_id    = var.project
   name          = "${var.prefix}-cloud-nat"
   region        = local.region
@@ -31,6 +31,8 @@ module "cloud_nat" {
   router        = "${var.prefix}-router"
   network       = module.vpc.network_self_link
   nat_ips       = module.nat_address[0].self_links
+  # this was disabled by default in v5.0.0, setting to true to retain previous behavior
+  enable_endpoint_independent_mapping = true
 }
 
 module "vpc" {

--- a/variables.tf
+++ b/variables.tf
@@ -242,7 +242,7 @@ variable "default_nodepool_locations" {
 
 variable "node_pools" {
   description = "Node pool definitions"
-  type        = map(object({
+  type = map(object({
     vm_type           = string
     os_disk_size      = number
     min_nodes         = string
@@ -260,7 +260,7 @@ variable "node_pools" {
       "min_nodes"    = 1
       "max_nodes"    = 5
       "node_taints"  = ["workload.sas.com/class=cas:NoSchedule"]
-      "node_labels"  = {
+      "node_labels" = {
         "workload.sas.com/class" = "cas"
       }
       "local_ssd_count"   = 0
@@ -273,7 +273,7 @@ variable "node_pools" {
       "min_nodes"    = 1
       "max_nodes"    = 5
       "node_taints"  = ["workload.sas.com/class=compute:NoSchedule"]
-      "node_labels"  = {
+      "node_labels" = {
         "workload.sas.com/class"        = "compute"
         "launcher.sas.com/prepullImage" = "sas-programming-environment"
       }
@@ -287,7 +287,7 @@ variable "node_pools" {
       "min_nodes"    = 1
       "max_nodes"    = 5
       "node_taints"  = ["workload.sas.com/class=stateless:NoSchedule"]
-      "node_labels"  = {
+      "node_labels" = {
         "workload.sas.com/class" = "stateless"
       }
       "local_ssd_count"   = 0
@@ -300,7 +300,7 @@ variable "node_pools" {
       "min_nodes"    = 1
       "max_nodes"    = 3
       "node_taints"  = ["workload.sas.com/class=stateful:NoSchedule"]
-      "node_labels"  = {
+      "node_labels" = {
         "workload.sas.com/class" = "stateful"
       }
       "local_ssd_count"   = 0
@@ -350,7 +350,7 @@ variable "cluster_autoscaling_max_memory_gb" {
 variable "postgres_server_defaults" {
   description = "default values for a postgres server"
   type        = any
-  default     = {
+  default = {
     machine_type                           = "db-custom-8-30720"
     storage_gb                             = 10
     backups_enabled                        = true

--- a/versions.tf
+++ b/versions.tf
@@ -15,27 +15,27 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.25.2" # Constrained by Google
+      version = "~> 2.25" # Constrained by Google
     }
     local = {
       source  = "hashicorp/local"
-      version = "~> 2.4.1"
+      version = "~> 2.4"
     }
     random = {
       source  = "hashicorp/random"
-      version = "~> 3.6.0" # Constrained by Google
+      version = "~> 3.6" # Constrained by Google
     }
     null = {
       source  = "hashicorp/null"
-      version = "~> 3.2.2" # Constrained by Google
+      version = "~> 3.2" # Constrained by Google
     }
     external = {
       source  = "hashicorp/external"
-      version = "~> 2.3.2" # Constrained by Google
+      version = "~> 2.3" # Constrained by Google
     }
     time = {
       source  = "hashicorp/time"
-      version = "~> 0.10.0"
+      version = "~> 0.10"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -7,35 +7,35 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "4.63.1"
+      version = "5.12.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "4.63.1"
+      version = "5.12.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "2.20.0" # Constrained by Google
+      version = "2.25.2" # Constrained by Google
     }
     local = {
       source  = "hashicorp/local"
-      version = "2.4.0"
+      version = "2.4.1"
     }
     random = {
       source  = "hashicorp/random"
-      version = "3.5.1" # Constrained by Google
+      version = "3.6.0" # Constrained by Google
     }
     null = {
       source  = "hashicorp/null"
-      version = "3.2.1" # Constrained by Google
+      version = "3.2.2" # Constrained by Google
     }
     external = {
       source  = "hashicorp/external"
-      version = "2.3.1" # Constrained by Google
+      version = "2.3.2" # Constrained by Google
     }
     time = {
       source  = "hashicorp/time"
-      version = "0.9.1"
+      version = "0.10.0"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -15,27 +15,27 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "2.25.2" # Constrained by Google
+      version = "~> 2.25.2" # Constrained by Google
     }
     local = {
       source  = "hashicorp/local"
-      version = "2.4.1"
+      version = "~> 2.4.1"
     }
     random = {
       source  = "hashicorp/random"
-      version = "3.6.0" # Constrained by Google
+      version = "~> 3.6.0" # Constrained by Google
     }
     null = {
       source  = "hashicorp/null"
-      version = "3.2.2" # Constrained by Google
+      version = "~> 3.2.2" # Constrained by Google
     }
     external = {
       source  = "hashicorp/external"
-      version = "2.3.2" # Constrained by Google
+      version = "~> 2.3.2" # Constrained by Google
     }
     time = {
       source  = "hashicorp/time"
-      version = "0.10.0"
+      version = "~> 0.10.0"
     }
   }
 }


### PR DESCRIPTION
### Changes

Updates 3rd party dependencies in this project to resolve security findings from our scanning tool. Consumers of the Dockerfile will automatically have these updated dependencies installed, and users who directly run this project on this host will need to update the dependencies themselves. A note in the release notes will be made about this.

#### Version Updates

Here is a summary of version updates as well as code changes that needed to be made as result of the update.

#### Binaries

* Terraform 1.4.5 -> 1.7.0
* gcloud CLI 440.0.0 -> 460.0.0

#### Providers

##### hashicorp/google & hashicorp/google-beta
* Versions:
  * Initial Version: 4.63.1
  * Final Version: 5.12.0
    * Notes:
      * Required as of `hashicorp/google` `v5.12.0` when using `google_service_networking_connection` in conjunction with CloudSQL instances in order to cleanly delete resources we need to set `deletion_policy = "ABANDON"`
      * https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_networking_connection
* Change Log: https://github.com/hashicorp/terraform-provider-google/blob/main/CHANGELOG.md

##### hashicorp/kubernetes
* Versions:
  * Initial Version: 2.20.0
  * Final Version: ~> 2.25.2
    * Notes:
      * No notable breaking changes or deprecations observed that would affect us, mostly the addition of new features.
* Change Log: https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/CHANGELOG.md


##### hashicorp/null
* Versions:
  * Initial Version: 3.2.1
  * Final Version: ~> 3.2.2
    * Notes:
      * No notable breaking changes or deprecations observed that would affect us
* Change Log: https://github.com/hashicorp/terraform-provider-null/blob/main/CHANGELOG.md

##### hashicorp/random
* Versions:
  * Initial Version: 3.5.1
  * Final Version: ~> 3.6.0
    * Notes:
      * No notable breaking changes or deprecations observed that would affect us
* Change Log: https://github.com/hashicorp/terraform-provider-random/blob/main/CHANGELOG.md

##### hashicorp/local
* Versions:
  * Initial Version: 2.4.0
  * Final Version: ~> 2.4.1
    * Notes:
      * No notable breaking changes or deprecations observed that would affect us
* Change Log: https://github.com/hashicorp/terraform-provider-local/blob/main/CHANGELOG.md

##### hashicorp/external
* Versions:
  * Initial Version: 2.3.1
  * Final Version: ~> 2.3.2
    * Notes:
      * No notable breaking changes or deprecations observed that would affect us
* Change Log: https://github.com/hashicorp/terraform-provider-external/blob/main/CHANGELOG.md

##### hashicorp/time
* Versions:
  * Initial Version: 0.9.1
  * Final Version: ~> 0.10.0
    * Notes:
      * No notable breaking changes or deprecations observed that would affect us
* Change Log: https://github.com/hashicorp/terraform-provider-time/blob/main/CHANGELOG.md

#### Modules

##### terraform-google-modules/kubernetes-engine/google//modules/private-cluster
* Versions:
  * Initial Version: 25.0.0
  * Final Version: ~> 29.0.0
    * Notes:
      * New version needs TPGv5
      * A new variable `deletion_protection` is set to true by default, need to set this to false so that we can destroy the cluster. 
* Change Log: https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/blob/master/CHANGELOG.md
* Upgrade Notes v26: https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/blob/master/docs/upgrading_to_v26.0.md
* Upgrade Notes v29: https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/blob/master/docs/upgrading_to_v29.0.md


##### GoogleCloudPlatform/sql-db/google//modules/postgresql
* Versions:
  * Initial Version: 15.0.0
  * Final Version: ~> 18.2.0
    * Notes:
      * No notable breaking changes or deprecations observed that would affect us. New version needs TPG >= v4.80
* Change Log: https://github.com/terraform-google-modules/terraform-google-sql-db/blob/v18.2.0/CHANGELOG.md
* Upgrade Notes v17: https://github.com/terraform-google-modules/terraform-google-sql-db/blob/master/docs/upgrading_to_sql_db_17.0.0.md

##### terraform-google-modules/service-accounts/google
* Versions:
  * Initial Version: 4.2.1
  * Final Version: ~> 4.2.2
    * Notes:
      * No notable breaking changes or deprecations observed that would affect us. New version needs TPGv5
* Change Log: https://github.com/terraform-google-modules/terraform-google-service-accounts/blob/master/CHANGELOG.md

##### terraform-google-modules/address/google
* Versions:
  * Initial Version: 3.1.2
  * Final Version: ~> 3.2.0
    * Notes:
      * No notable breaking changes or deprecations observed that would affect us. New version needs TPGv5
* Change Log: https://github.com/terraform-google-modules/terraform-google-address/blob/master/CHANGELOG.md

##### terraform-google-modules/cloud-nat/google
* Versions:
  * Initial Version: 3.0.0
  * Final Version: ~> 5.0.0
    * Notes:
      * New version needs TPGv5
      * `enable_endpoint_independent_mapping` now defaults to false, explicitly setting it to true to retain previous behavior.
* Change Log: https://github.com/terraform-google-modules/terraform-google-cloud-nat/blob/master/CHANGELOG.md
* Upgrade Notes: https://github.com/terraform-google-modules/terraform-google-cloud-nat/blob/master/docs/upgrading_to_v5.0.md


Note: Although the versions have been bumped up, there are no breaking changes. A user could still modify their infrastructure they created with viya4-iac-gcp:5.0.0 with this latest release provided that they update their deps with `terraform init -upgrade` (a note will be included in the release notes)

### Tests

| Scenario | Provider | kubernetes_version  | order  | cadence   | notes                                                                                                                               |
|----------|----------|---------------------|--------|-----------|-------------------------------------------------------------------------------------------------------------------------------------|
| 1        | GCP      | v1.27.9-gke.1092000 | ****** | fast:2020 | OOTB deployment                                                                                                                     |
| 2        | GCP      | v1.27.9-gke.1092000 | N/A    | N/A       | Initial infra create with 5.0.0 and modification with PR code                                                                       |
| 3        | GCP      | v1.27.9-gke.1092000 | ****** | fast:2020 | Initial infra create with 5.0.0 and Viya deployment, stop Viya deployment, node adjustment with PR code, and resume Viya deployment |