### PR TITLE
feat: (IAC-1348) Update the default Postgres server version to 15

### DIFF
--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -264,7 +264,7 @@ Each server element, like `foo = {}`, can contain none, some, or all of the para
 | backup_count | The number of automated backups to retain, from 1 to 365 | string | "7" | Take note this is a **COUNT** not number of days |
 | administrator_login | The Administrator Login for the PostgreSQL Server. Changing this forces a new resource to be created. | string | "pgadmin" | | |
 | administrator_password | The Password associated with the administrator_login for the PostgreSQL Server | string | "my$up3rS3cretPassw0rd" |  |
-| server_version | The version of the  PostgreSQL server instance | string | "13" | Refer to the [SAS Viya Platform Administration Guide](https://documentation.sas.com/?cdcId=sasadmincdc&cdcVersion=default&docsetId=itopssr&docsetTarget=p05lfgkwib3zxbn1t6nyihexp12n.htm#p1wq8ouke3c6ixn1la636df9oa1u) for the supported versions of PostgreSQL for the SAS Viya platform. |
+| server_version | The version of the  PostgreSQL server instance | string | "15" | Refer to the [SAS Viya Platform Administration Guide](https://documentation.sas.com/?cdcId=sasadmincdc&cdcVersion=default&docsetId=itopssr&docsetTarget=p05lfgkwib3zxbn1t6nyihexp12n.htm#p1wq8ouke3c6ixn1la636df9oa1u) for the supported versions of PostgreSQL for the SAS Viya platform. |
 | ssl_enforcement_enabled | Enforce SSL on connection to the PostgreSQL database | bool | true | |
 | availability_type | The availability type for the master instance. | string | "ZONAL" | This is only used to set up high availability for the PostgreSQL instance. Can be either `ZONAL` or `REGIONAL`. |
 | database_flags | Database flags for the master instance. | list(object({})) |  | More details can be found [here](https://cloud.google.com/sql/docs/postgres/flags) |
@@ -288,7 +288,7 @@ postgres_servers = {
     backup_count                           = 7 # Number of backups to retain, not in days
     administrator_login                    = "cdsadmin"
     administrator_password                 = "my$up3rS3cretPassw0rd"
-    server_version                         = "13"
+    server_version                         = "15"
     availability_type                      = "ZONAL"
     ssl_enforcement_enabled                = true
     database_flags                         = [{ name = "foo" value = "true"}, { name = "bar", value = "false"}]

--- a/variables.tf
+++ b/variables.tf
@@ -360,7 +360,7 @@ variable "postgres_server_defaults" {
     backup_count                           = "7" # Number of backups to retain, not days
     administrator_login                    = "pgadmin"
     administrator_password                 = "my$up3rS3cretPassw0rd"
-    server_version                         = "13"
+    server_version                         = "15"
     availability_type                      = "ZONAL"
     ssl_enforcement_enabled                = true
     database_flags                         = []


### PR DESCRIPTION
### Changes

Update the default postgres `server_version` to 15


### Tests

| Scenario | Provider | kubernetes_version   | server_version | Final Postgres Version | order  | cadence   |
|----------|----------|----------------------|----------------|------------------------|--------|-----------|
| 1        | GCP      | v1.27.10-gke.1152000 | 15             | POSTGRES_15_4          | ****** | fast:2020 | 

