### PR TITLE
feat: (IAC-1437) Update Dependencies to Resolve Security Warnings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ARG TERRAFORM_VERSION=1.7.3
-ARG GCP_CLI_VERSION=471.0.0
+ARG GCP_CLI_VERSION=472.0.0
 
 FROM hashicorp/terraform:$TERRAFORM_VERSION as terraform
 FROM google/cloud-sdk:$GCP_CLI_VERSION-alpine

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN apk update \
   && chmod g=u -R /etc/passwd /etc/group /viya4-iac-gcp \
   && git config --system --add safe.directory /viya4-iac-gcp \
   && terraform init \
-  && gcloud components install gke-gcloud-auth-plugin alpha beta cloud_sql_proxy $INSTALL_COMPONENTS \
+  && gcloud components install gke-gcloud-auth-plugin alpha beta cloud-sql-proxy $INSTALL_COMPONENTS \
   && rm -rf /google-cloud-sdk/.install/.backup
 
 ENV TF_VAR_iac_tooling=docker

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Operational knowledge of
     - [Terraform](https://www.terraform.io/downloads.html) - v1.7.3
     - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl) - v1.28.7
     - [jq](https://stedolan.github.io/jq/) - v1.6
-    - [gcloud CLI](https://cloud.google.com/sdk/gcloud) - (optional - useful as an alternative to the Google Cloud Platform Portal) - v471.0.0
+    - [gcloud CLI](https://cloud.google.com/sdk/gcloud) - (optional - useful as an alternative to the Google Cloud Platform Portal) - v472.0.0
     - [gke-gcloud-auth-plugin](https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-access-for-kubectl#install_plugin) - (optional - only for provider based Kubernetes configuration files) - >= v1.26
   - #### Docker
     - [Docker](https://docs.docker.com/get-docker/)


### PR DESCRIPTION
### Changes

Updated the gcloud version to 472.0.0 to resolve security vulnerabilities 

### Tests

| Scenario | Provider | kubernetes_version  | Order  | Cadence   | Notes |
|----------|----------|---------------------|--------|-----------|-------|
| 1        | GCP      | v1.28.9-gke.1000000 | ****** | fast:2020 | OOTB  |