### PR TITLE
feat: (IAC-1025) Update IAC Sample Sizing

### DIFF
--- a/config/sample-input-tf-enterprise.tfvars
+++ b/config/sample-input-tf-enterprise.tfvars
@@ -40,13 +40,13 @@ create_static_kubeconfig = true
 # GKE config
 kubernetes_version         = "1.28"
 default_nodepool_min_nodes = 1
-default_nodepool_vm_type   = "n2-standard-2"
+default_nodepool_vm_type   = "n2-highmem-8"
 
-## Cluster Node Pools config - mimimal
+## Cluster Node Pools config - minimal
 cluster_node_pool_mode = "minimal"
 node_pools = {
   cas = {
-    "vm_type"      = "n2-highmem-4"
+    "vm_type"      = "n2-highmem-16"
     "os_disk_size" = 200
     "min_nodes"    = 0
     "max_nodes"    = 5
@@ -54,12 +54,12 @@ node_pools = {
     "node_labels" = {
       "workload.sas.com/class" = "cas"
     }
-    "local_ssd_count"   = 0
+    "local_ssd_count"   = 2
     "accelerator_count" = 0
     "accelerator_type"  = ""
   },
   generic = {
-    "vm_type"      = "n2-standard-8"
+    "vm_type"      = "n2-highmem-4"
     "os_disk_size" = 200
     "min_nodes"    = 0
     "max_nodes"    = 5
@@ -84,7 +84,7 @@ storage_type = "standard"
 # required ONLY when storage_type is "standard" to create NFS Server VM
 create_nfs_public_ip = false
 nfs_vm_admin         = "nfsuser"
-nfs_vm_type          = "n2-standard-4"
+nfs_vm_type          = "n2-highmem-4"
 nfs_raid_disk_size   = 128
 
 # Postgres config - By having this entry a database server is created. If you do not

--- a/config/sample-input-tf-enterprise.tfvars
+++ b/config/sample-input-tf-enterprise.tfvars
@@ -85,7 +85,7 @@ storage_type = "standard"
 create_nfs_public_ip = false
 nfs_vm_admin         = "nfsuser"
 nfs_vm_type          = "n2-highmem-4"
-nfs_raid_disk_size   = 128
+nfs_raid_disk_size   = 1000
 
 # Postgres config - By having this entry a database server is created. If you do not
 #                   need an external database server remove the 'postgres_servers'

--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -125,7 +125,7 @@ The application of a Kubernetes version in GCP has some limitations when assigni
 
 | Name | Description | Type | Default | Notes |
 | :--- | ---: | ---: | ---: | ---: |
-| default_nodepool_vm_type | Type of the default nodepool VMs | string | "e2-standard-8" | |
+| default_nodepool_vm_type | Type of the default nodepool VMs | string | "n2-highmem-8" | |
 | default_nodepool_os_disk_size | Disk size for default nodepool VMs in GB | number | 128 ||
 | default_nodepool_min_nodes | Minimum number of nodes for the default nodepool | number | 1 | |
 | default_nodepool_max_nodes | Maximum number of nodes for the default nodepool | number | 5 | |
@@ -153,7 +153,7 @@ The default values for the `node_pools` variable are:
 
 ```yaml
 cas = {
-  "vm_type"      = "n1-highmem-16"
+  "vm_type"      = "n2-highmem-16"
   "os_disk_size" = 200
   "min_nodes"    = 1
   "max_nodes"    = 5
@@ -161,12 +161,12 @@ cas = {
   "node_labels" = {
     "workload.sas.com/class" = "cas"
   }
-  "local_ssd_count"   = 0
+  "local_ssd_count"   = 2
   "accelerator_count" = 0
   "accelerator_type" = ""
 },
 compute = {
-  "vm_type"      = "n1-highmem-16"
+  "vm_type"      = "n2-highmem-4"
   "os_disk_size" = 200
   "min_nodes"    = 1
   "max_nodes"    = 5
@@ -175,12 +175,12 @@ compute = {
     "workload.sas.com/class"        = "compute"
     "launcher.sas.com/prepullImage" = "sas-programming-environment"
   }
-  "local_ssd_count"   = 0
+  "local_ssd_count"   = 1
   "accelerator_count" = 0
   "accelerator_type"  = ""
 },
 stateless = {
-  "vm_type"      = "e2-standard-16"
+  "vm_type"      = "n2-highmem-4"
   "os_disk_size" = 200
   "min_nodes"    = 1
   "max_nodes"    = 5
@@ -193,7 +193,7 @@ stateless = {
   "accelerator_type"  = ""
 },
 stateful = {
-  "vm_type"      = "e2-standard-8"
+  "vm_type"      = "n2-highmem-4"
   "os_disk_size" = 200
   "min_nodes"    = 1
   "max_nodes"    = 3
@@ -219,7 +219,7 @@ stateful = {
 | :--- | ---: | ---: | ---: | ---: |
 | create_nfs_public_ip | Add public ip to the NFS server VM | bool | false | The NFS server VM is only created when storage_type="standard" |
 | nfs_vm_admin | OS Admin User for the NFS server VM | string | "nfsuser" | The NFS server VM is only created when storage_type="standard" |
-| nfs_raid_disk_size | Size in Gb for each disk of the RAID5 cluster on the NFS server VM | number | 128 | The NFS server VM is only created when storage_type="standard" |
+| nfs_raid_disk_size | Size in Gb for each disk of the RAID5 cluster on the NFS server VM | number | 1000 | The NFS server VM is only created when storage_type="standard" |
 
 ### For `storage_type=ha` only (Google Filestore)
 
@@ -256,8 +256,8 @@ Each server element, like `foo = {}`, can contain none, some, or all of the para
 
 | Name | Description | Type | Default | Notes |
 | :--- | ---: | ---: | ---: | ---: |
-| machine_type| The machine type for the PostgreSQL server VMs" | string | "db-custom-8-30720" | Google Cloud Postgres supports only shared-core machine types such as db-f1-micro, and custom machine types such as db-custom-2-13312. |
-| storage_gb | Minimum storage allowed for the PostgreSQL server | number | 10 | |
+| machine_type| The machine type for the PostgreSQL server VMs" | string | "db-custom-4-16384" | Google Cloud Postgres supports only shared-core machine types such as db-f1-micro, and custom machine types such as db-custom-2-13312. |
+| storage_gb | Minimum storage allowed for the PostgreSQL server | number | 128 | |
 | backups_enabled | Enables postgres backups | bool | true | |
 | backups_start_time | Start time for postgres backups | string | "21:00" | |
 | backups_location | TODO | string | null | |
@@ -280,8 +280,8 @@ postgres_servers = {
     administrator_password       = "D0ntL00kTh1sWay"
   },
   cds-postgres = {
-    machine_type                           = "db-custom-8-30720"
-    storage_gb                             = 10
+    machine_type                           = "db-custom-4-16384"
+    storage_gb                             = 128
     backups_enabled                        = true
     backups_start_time                     = "21:00"
     backups_location                       = null

--- a/examples/sample-input-byo.tfvars
+++ b/examples/sample-input-byo.tfvars
@@ -39,12 +39,12 @@ postgres_servers = {
 # GKE config
 kubernetes_version         = "1.28"
 default_nodepool_min_nodes = 2
-default_nodepool_vm_type   = "e2-standard-8"
+default_nodepool_vm_type   = "n2-highmem-8"
 
 # Node Pools config
 node_pools = {
   cas = {
-    "vm_type"      = "n1-highmem-16"
+    "vm_type"      = "n2-highmem-16"
     "os_disk_size" = 200
     "min_nodes"    = 1
     "max_nodes"    = 1
@@ -52,12 +52,12 @@ node_pools = {
     "node_labels" = {
       "workload.sas.com/class" = "cas"
     }
-    "local_ssd_count"   = 0
+    "local_ssd_count"   = 2
     "accelerator_count" = 0
     "accelerator_type"  = ""
   },
   compute = {
-    "vm_type"      = "n1-highmem-16"
+    "vm_type"      = "n2-highmem-4"
     "os_disk_size" = 200
     "min_nodes"    = 1
     "max_nodes"    = 1
@@ -66,15 +66,15 @@ node_pools = {
       "workload.sas.com/class"        = "compute"
       "launcher.sas.com/prepullImage" = "sas-programming-environment"
     }
-    "local_ssd_count"   = 0
+    "local_ssd_count"   = 1
     "accelerator_count" = 0
     "accelerator_type"  = ""
   },
   stateless = {
-    "vm_type"      = "e2-standard-16"
+    "vm_type"      = "n2-highmem-4"
     "os_disk_size" = 200
     "min_nodes"    = 1
-    "max_nodes"    = 2
+    "max_nodes"    = 4
     "node_taints"  = ["workload.sas.com/class=stateless:NoSchedule"]
     "node_labels" = {
       "workload.sas.com/class" = "stateless"
@@ -84,10 +84,10 @@ node_pools = {
     "accelerator_type"  = ""
   },
   stateful = {
-    "vm_type"      = "e2-standard-8"
+    "vm_type"      = "n2-highmem-4"
     "os_disk_size" = 200
     "min_nodes"    = 1
-    "max_nodes"    = 3
+    "max_nodes"    = 2
     "node_taints"  = ["workload.sas.com/class=stateful:NoSchedule"]
     "node_labels" = {
       "workload.sas.com/class" = "stateful"
@@ -108,4 +108,4 @@ storage_type = "standard"
 # required ONLY when storage_type is "standard" to create NFS Server VM
 create_nfs_public_ip = false
 nfs_vm_admin         = "nfsuser"
-nfs_raid_disk_size   = 128
+nfs_raid_disk_size   = 1000

--- a/examples/sample-input-connect.tfvars
+++ b/examples/sample-input-connect.tfvars
@@ -29,12 +29,12 @@ postgres_servers = {
 # GKE config
 kubernetes_version         = "1.28"
 default_nodepool_min_nodes = 2
-default_nodepool_vm_type   = "e2-standard-8"
+default_nodepool_vm_type   = "n2-highmem-8"
 
 # Node Pools config
 node_pools = {
   cas = {
-    "vm_type"      = "n1-highmem-16"
+    "vm_type"      = "n2-highmem-16"
     "os_disk_size" = 200
     "min_nodes"    = 1
     "max_nodes"    = 1
@@ -42,12 +42,12 @@ node_pools = {
     "node_labels" = {
       "workload.sas.com/class" = "cas"
     }
-    "local_ssd_count"   = 0
+    "local_ssd_count"   = 2
     "accelerator_count" = 0
     "accelerator_type"  = ""
   },
   compute = {
-    "vm_type"      = "n1-highmem-16"
+    "vm_type"      = "n2-highmem-4"
     "os_disk_size" = 200
     "min_nodes"    = 1
     "max_nodes"    = 1
@@ -56,12 +56,12 @@ node_pools = {
       "workload.sas.com/class"        = "compute"
       "launcher.sas.com/prepullImage" = "sas-programming-environment"
     }
-    "local_ssd_count"   = 0
+    "local_ssd_count"   = 1
     "accelerator_count" = 0
     "accelerator_type"  = ""
   },
   connect = {
-    "vm_type"      = "n1-highmem-16"
+    "vm_type"      = "n2-highmem-16"
     "os_disk_size" = 200
     "min_nodes"    = 1
     "max_nodes"    = 1
@@ -75,10 +75,10 @@ node_pools = {
     "accelerator_type"  = ""
   },
   stateless = {
-    "vm_type"      = "e2-standard-16"
+    "vm_type"      = "n2-highmem-4"
     "os_disk_size" = 200
     "min_nodes"    = 1
-    "max_nodes"    = 2
+    "max_nodes"    = 4
     "node_taints"  = ["workload.sas.com/class=stateless:NoSchedule"]
     "node_labels" = {
       "workload.sas.com/class" = "stateless"
@@ -88,10 +88,10 @@ node_pools = {
     "accelerator_type"  = ""
   },
   stateful = {
-    "vm_type"      = "e2-standard-8"
+    "vm_type"      = "n2-highmem-4"
     "os_disk_size" = 200
     "min_nodes"    = 1
-    "max_nodes"    = 3
+    "max_nodes"    = 2
     "node_taints"  = ["workload.sas.com/class=stateful:NoSchedule"]
     "node_labels" = {
       "workload.sas.com/class" = "stateful"
@@ -111,4 +111,4 @@ storage_type = "standard"
 # required ONLY when storage_type is "standard" to create NFS Server VM
 create_nfs_public_ip = false
 nfs_vm_admin         = "nfsuser"
-nfs_raid_disk_size   = 128
+nfs_raid_disk_size   = 1000

--- a/examples/sample-input-ha.tfvars
+++ b/examples/sample-input-ha.tfvars
@@ -29,12 +29,12 @@ postgres_servers = {
 # GKE config
 kubernetes_version         = "1.28"
 default_nodepool_min_nodes = 2
-default_nodepool_vm_type   = "e2-standard-8"
+default_nodepool_vm_type   = "n2-highmem-8"
 
 # Node Pools config
 node_pools = {
   cas = {
-    "vm_type"      = "n1-highmem-16"
+    "vm_type"      = "n2-highmem-16"
     "os_disk_size" = 200
     "min_nodes"    = 2
     "max_nodes"    = 3
@@ -42,29 +42,29 @@ node_pools = {
     "node_labels" = {
       "workload.sas.com/class" = "cas"
     }
-    "local_ssd_count"   = 0
+    "local_ssd_count"   = 2
     "accelerator_count" = 0
     "accelerator_type"  = ""
   },
   compute = {
-    "vm_type"      = "n1-highmem-16"
+    "vm_type"      = "n2-highmem-4"
     "os_disk_size" = 200
     "min_nodes"    = 2
     "max_nodes"    = 3
     "node_taints"  = ["workload.sas.com/class=compute:NoSchedule"]
     "node_labels" = {
-      "workload.sas.com/class"       = "compute"
-      "launcher.sas.comprepullImage" = "sas-programming-environment"
+      "workload.sas.com/class"        = "compute"
+      "launcher.sas.com/prepullImage" = "sas-programming-environment"
     }
-    "local_ssd_count"   = 0
+    "local_ssd_count"   = 1
     "accelerator_count" = 0
     "accelerator_type"  = ""
   },
   stateless = {
-    "vm_type"      = "e2-standard-16"
+    "vm_type"      = "n2-highmem-4"
     "os_disk_size" = 200
     "min_nodes"    = 2
-    "max_nodes"    = 3
+    "max_nodes"    = 4
     "node_taints"  = ["workload.sas.com/class=stateless:NoSchedule"]
     "node_labels" = {
       "workload.sas.com/class" = "stateless"
@@ -74,10 +74,10 @@ node_pools = {
     "accelerator_type"  = ""
   },
   stateful = {
-    "vm_type"      = "e2-standard-8"
+    "vm_type"      = "n2-highmem-4"
     "os_disk_size" = 200
     "min_nodes"    = 2
-    "max_nodes"    = 3
+    "max_nodes"    = 4
     "node_taints"  = ["workload.sas.com/class=stateful:NoSchedule"]
     "node_labels" = {
       "workload.sas.com/class" = "stateful"

--- a/examples/sample-input-minimal.tfvars
+++ b/examples/sample-input-minimal.tfvars
@@ -29,13 +29,13 @@ tags = {} # e.g., { "key1" = "value1", "key2" = "value2" }
 # GKE config
 kubernetes_version         = "1.28"
 default_nodepool_min_nodes = 1
-default_nodepool_vm_type   = "n2-standard-2"
+default_nodepool_vm_type   = "n2-highmem-8"
 
-## Cluster Node Pools config - mimimal
+## Cluster Node Pools config - minimal
 cluster_node_pool_mode = "minimal"
 node_pools = {
   cas = {
-    "vm_type"      = "n2-highmem-4"
+    "vm_type"      = "n2-highmem-16"
     "os_disk_size" = 200
     "min_nodes"    = 0
     "max_nodes"    = 5
@@ -43,12 +43,12 @@ node_pools = {
     "node_labels" = {
       "workload.sas.com/class" = "cas"
     }
-    "local_ssd_count"   = 0
+    "local_ssd_count"   = 2
     "accelerator_count" = 0
     "accelerator_type"  = ""
   },
   generic = {
-    "vm_type"      = "n2-standard-8"
+    "vm_type"      = "n2-highmem-4"
     "os_disk_size" = 200
     "min_nodes"    = 0
     "max_nodes"    = 5
@@ -73,5 +73,5 @@ storage_type = "standard"
 # required ONLY when storage_type is "standard" to create NFS Server VM
 create_nfs_public_ip = false
 nfs_vm_admin         = "nfsuser"
-nfs_vm_type          = "n2-standard-4"
-nfs_raid_disk_size   = 128
+nfs_vm_type          = "n2-highmem-4"
+nfs_raid_disk_size   = 1000

--- a/examples/sample-input.tfvars
+++ b/examples/sample-input.tfvars
@@ -29,12 +29,12 @@ postgres_servers = {
 # GKE config
 kubernetes_version         = "1.28"
 default_nodepool_min_nodes = 2
-default_nodepool_vm_type   = "e2-standard-8"
+default_nodepool_vm_type   = "n2-highmem-8"
 
 # Node Pools config
 node_pools = {
   cas = {
-    "vm_type"      = "n1-highmem-16"
+    "vm_type"      = "n2-highmem-16"
     "os_disk_size" = 200
     "min_nodes"    = 1
     "max_nodes"    = 1
@@ -42,12 +42,12 @@ node_pools = {
     "node_labels" = {
       "workload.sas.com/class" = "cas"
     }
-    "local_ssd_count"   = 0
+    "local_ssd_count"   = 2
     "accelerator_count" = 0
     "accelerator_type"  = ""
   },
   compute = {
-    "vm_type"      = "n1-highmem-16"
+    "vm_type"      = "n2-highmem-4"
     "os_disk_size" = 200
     "min_nodes"    = 1
     "max_nodes"    = 1
@@ -56,15 +56,15 @@ node_pools = {
       "workload.sas.com/class"        = "compute"
       "launcher.sas.com/prepullImage" = "sas-programming-environment"
     }
-    "local_ssd_count"   = 0
+    "local_ssd_count"   = 1
     "accelerator_count" = 0
     "accelerator_type"  = ""
   },
   stateless = {
-    "vm_type"      = "e2-standard-16"
+    "vm_type"      = "n2-highmem-4"
     "os_disk_size" = 200
     "min_nodes"    = 1
-    "max_nodes"    = 2
+    "max_nodes"    = 4
     "node_taints"  = ["workload.sas.com/class=stateless:NoSchedule"]
     "node_labels" = {
       "workload.sas.com/class" = "stateless"
@@ -74,10 +74,10 @@ node_pools = {
     "accelerator_type"  = ""
   },
   stateful = {
-    "vm_type"      = "e2-standard-8"
+    "vm_type"      = "n2-highmem-4"
     "os_disk_size" = 200
     "min_nodes"    = 1
-    "max_nodes"    = 3
+    "max_nodes"    = 2
     "node_taints"  = ["workload.sas.com/class=stateful:NoSchedule"]
     "node_labels" = {
       "workload.sas.com/class" = "stateful"
@@ -97,4 +97,4 @@ storage_type = "standard"
 # required ONLY when storage_type is "standard" to create NFS Server VM
 create_nfs_public_ip = false
 nfs_vm_admin         = "nfsuser"
-nfs_raid_disk_size   = 128
+nfs_raid_disk_size   = 1000

--- a/variables.tf
+++ b/variables.tf
@@ -158,13 +158,13 @@ variable "nfs_vm_admin" {
 variable "nfs_vm_type" {
   description = "NFS VM type"
   type        = string
-  default     = "n2-standard-4"
+  default     = "n2-highmem-4"
 }
 
 variable "nfs_raid_disk_size" {
   description = "Size in Gb for each disk of the RAID5 cluster"
   type        = number
-  default     = 128
+  default     = 1000
 }
 
 variable "create_nfs_public_ip" {
@@ -194,7 +194,7 @@ variable "minimum_initial_nodes" {
 variable "default_nodepool_vm_type" {
   description = "Type of the default nodepool VMs"
   type        = string
-  default     = "e2-standard-8"
+  default     = "n2-highmem-8"
 }
 
 variable "default_nodepool_local_ssd_count" {
@@ -255,7 +255,7 @@ variable "node_pools" {
   }))
   default = {
     cas = {
-      "vm_type"      = "n1-highmem-16"
+      "vm_type"      = "n2-highmem-16"
       "os_disk_size" = 200
       "min_nodes"    = 1
       "max_nodes"    = 5
@@ -263,29 +263,29 @@ variable "node_pools" {
       "node_labels" = {
         "workload.sas.com/class" = "cas"
       }
-      "local_ssd_count"   = 0
+      "local_ssd_count"   = 2
       "accelerator_count" = 0
       "accelerator_type"  = ""
     },
     compute = {
-      "vm_type"      = "n1-highmem-16"
+      "vm_type"      = "n2-highmem-4"
       "os_disk_size" = 200
       "min_nodes"    = 1
-      "max_nodes"    = 5
+      "max_nodes"    = 1
       "node_taints"  = ["workload.sas.com/class=compute:NoSchedule"]
       "node_labels" = {
         "workload.sas.com/class"        = "compute"
         "launcher.sas.com/prepullImage" = "sas-programming-environment"
       }
-      "local_ssd_count"   = 0
+      "local_ssd_count"   = 1
       "accelerator_count" = 0
       "accelerator_type"  = ""
     },
     stateless = {
-      "vm_type"      = "e2-standard-16"
+      "vm_type"      = "n2-highmem-4"
       "os_disk_size" = 200
       "min_nodes"    = 1
-      "max_nodes"    = 5
+      "max_nodes"    = 4
       "node_taints"  = ["workload.sas.com/class=stateless:NoSchedule"]
       "node_labels" = {
         "workload.sas.com/class" = "stateless"
@@ -295,10 +295,10 @@ variable "node_pools" {
       "accelerator_type"  = ""
     },
     stateful = {
-      "vm_type"      = "e2-standard-8"
+      "vm_type"      = "n2-highmem-4"
       "os_disk_size" = 200
       "min_nodes"    = 1
-      "max_nodes"    = 3
+      "max_nodes"    = 2
       "node_taints"  = ["workload.sas.com/class=stateful:NoSchedule"]
       "node_labels" = {
         "workload.sas.com/class" = "stateful"
@@ -339,7 +339,7 @@ variable "cluster_autoscaling_max_cpu_cores" {
 }
 
 variable "cluster_autoscaling_max_memory_gb" {
-  description = "Max number of gb of memory in the cluster	"
+  description = "Max number of gb of memory in the cluster"
   type        = number
   default     = 10000
 }
@@ -357,8 +357,8 @@ variable "postgres_server_defaults" {
   description = "default values for a postgres server"
   type        = any
   default = {
-    machine_type                           = "db-custom-8-30720"
-    storage_gb                             = 10
+    machine_type                           = "db-custom-4-15360"
+    storage_gb                             = 128
     backups_enabled                        = true
     backups_start_time                     = "21:00"
     backups_location                       = null

--- a/variables.tf
+++ b/variables.tf
@@ -357,7 +357,7 @@ variable "postgres_server_defaults" {
   description = "default values for a postgres server"
   type        = any
   default = {
-    machine_type                           = "db-custom-4-15360"
+    machine_type                           = "db-custom-4-16384"
     storage_gb                             = 128
     backups_enabled                        = true
     backups_start_time                     = "21:00"


### PR DESCRIPTION
### Changes

Updated examples, defaults, and docs to line up with sizing recommendations.

### Tests

| Scenario | Provider | Example File                 | kubernetes_version   | Order  | Cadence   |
|----------|----------|------------------------------|----------------------|--------|-----------|
| 1        | GCP      | sample-input.tfvars          | v1.28.10-gke.1058000 | ****** | fast:2020 |
| 2        | GCP      | sample-input-connect.tfvars  | v1.28.10-gke.1058000 |        |           |
| 3        | GCP      | sample-input-defaults.tfvars | v1.29.5-gke.1060000  |        |           |
| 4        | GCP      | sample-input-ha.tfvars       | v1.28.10-gke.1058000 |        |           |
| 5        | GCP      | sample-input-minimal.tfvars  | v1.28.10-gke.1058000 |        |           |
| 6        | GCP      | sample-input-byo.tfvars      | v1.28.10-gke.1058000 |        |           |