### PR TITLE
feat!: (IAC-1474) Update binaries & Terraform providers/modules

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # Copyright © 2021-2024, SAS Institute Inc., Cary, NC, USA. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-ARG TERRAFORM_VERSION=1.7.3
-ARG GCP_CLI_VERSION=472.0.0
+ARG TERRAFORM_VERSION=1.8.5
+ARG GCP_CLI_VERSION=479.0.0
 
 FROM hashicorp/terraform:$TERRAFORM_VERSION as terraform
 FROM google/cloud-sdk:$GCP_CLI_VERSION-alpine

--- a/README.md
+++ b/README.md
@@ -31,10 +31,10 @@ Operational knowledge of
 
 - Terraform or Docker
   - #### Terraform
-    - [Terraform](https://www.terraform.io/downloads.html) - v1.7.3
+    - [Terraform](https://www.terraform.io/downloads.html) - v1.8.5
     - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl) - v1.28.7
     - [jq](https://stedolan.github.io/jq/) - v1.6
-    - [gcloud CLI](https://cloud.google.com/sdk/gcloud) - (optional - useful as an alternative to the Google Cloud Platform Portal) - v472.0.0
+    - [gcloud CLI](https://cloud.google.com/sdk/gcloud) - (optional - useful as an alternative to the Google Cloud Platform Portal) - v479.0.0
     - [gke-gcloud-auth-plugin](https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-access-for-kubectl#install_plugin) - (optional - only for provider based Kubernetes configuration files) - >= v1.26
   - #### Docker
     - [Docker](https://docs.docker.com/get-docker/)

--- a/main.tf
+++ b/main.tf
@@ -91,7 +91,7 @@ data "google_container_engine_versions" "gke-version" {
 
 module "gke" {
   source                        = "terraform-google-modules/kubernetes-engine/google//modules/private-cluster"
-  version                       = "~> 30.0.0"
+  version                       = "~> 31.0.0"
   project_id                    = var.project
   name                          = "${var.prefix}-gke"
   region                        = local.region
@@ -241,7 +241,7 @@ resource "local_file" "kubeconfig" {
 # Module Registry - https://registry.terraform.io/modules/GoogleCloudPlatform/sql-db/google/12.0.0/submodules/postgresql
 module "postgresql" {
   source     = "GoogleCloudPlatform/sql-db/google//modules/postgresql"
-  version    = "~> 19.0.0"
+  version    = "~> 20.1.0"
   project_id = var.project
 
   for_each = local.postgres_servers != null ? length(local.postgres_servers) != 0 ? local.postgres_servers : {} : {}

--- a/modules/google_vm/main.tf
+++ b/modules/google_vm/main.tf
@@ -3,7 +3,7 @@
 
 module "address" {
   source       = "terraform-google-modules/address/google"
-  version      = "~> 3.2.0"
+  version      = "~> 4.0.0"
   project_id   = var.project
   region       = var.region
   address_type = "EXTERNAL"

--- a/network.tf
+++ b/network.tf
@@ -11,7 +11,7 @@ data "google_compute_address" "nat_address" {
 module "nat_address" {
   count        = length(var.nat_address_name) == 0 ? 1 : 0
   source       = "terraform-google-modules/address/google"
-  version      = "~> 3.2.0"
+  version      = "~> 4.0.0"
   project_id   = var.project
   region       = local.region
   address_type = "EXTERNAL"
@@ -23,7 +23,7 @@ module "nat_address" {
 module "cloud_nat" {
   count         = length(var.nat_address_name) == 0 ? 1 : 0
   source        = "terraform-google-modules/cloud-nat/google"
-  version       = "~> 5.0.0"
+  version       = "~> 5.1.0"
   project_id    = var.project
   name          = "${var.prefix}-cloud-nat"
   region        = local.region

--- a/versions.tf
+++ b/versions.tf
@@ -2,16 +2,16 @@
 # SPDX-License-Identifier: Apache-2.0
 
 terraform {
-  required_version = ">= 1.4.5"
+  required_version = ">= 1.8.0"
 
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "5.16.0"
+      version = "5.31.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "5.16.0"
+      version = "5.31.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"


### PR DESCRIPTION
## Breaking Notes:

This is a breaking change and will be noted as so in the release notes.
To resolve security warnings we needed to bump up the version of the providers which in turn required us to bump up the minimum required terraform versions.

This transition to this new version should be smooth. Users who run this project directly on their host will need to update the terraform binary and update the providers and modules. Users of the Docker container can build and use the latest release. Users will not be able to manage their infrastructure using an older version of this project once they migrate to this version or initially start with it. More details to come in official release notes. 

### Changes

Update binaries & Terraform providers/modules to resolve security warnings

#### Binaries

* Terraform 1.7.3-> 1.8.5 (project min is 1.8.0)
* gcloud CLI 472.0.0 -> 479.0.0

#### Providers

##### hashicorp/google & hashicorp/google-beta
* Versions:
  * Initial Version: 5.16.0
  * Final Version: 5.31.0
    * Notes:
      * No notable breaking changes or deprecations observed that would affect us, mostly the addition of new features/fixes.
* Change Log: https://github.com/hashicorp/terraform-provider-google/blob/main/CHANGELOG.md

#### Modules

##### terraform-google-modules/kubernetes-engine/google//modules/private-cluster
* Versions:
  * Initial Version: ~> 30.0.0
  * Final Version: ~> 31.0.0
    * Notes:
      * No notable breaking changes or deprecations observed that would affect us. This update requires upgrading the minimum provider version 5.25 which will be met in this PR.
* Change Log: https://github.com/terraform-google-modules/terraform-google-kubernetes-engine
* Upgrade to v31 Guide: https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/blob/master/docs/upgrading_to_v31.0.md

##### terraform-google-modules/address/google
* Versions:
  * Initial Version: ~> 3.2.0
  * Final Version: ~> 4.0.0
    * Notes:
      * No breaking feature additions/removals, new version just requires TPG>=5.2
* Change Log: https://github.com/terraform-google-modules/terraform-google-address/blob/master/CHANGELOG.md

##### GoogleCloudPlatform/sql-db/google//modules/postgresql
* Versions:
  * Initial Version: ~> 19.0.0
  * Final Version: ~> 20.1.0
    * Notes:
      * No notable breaking changes or deprecations observed that would affect us. This update requires upgrading the minimum provider version 5.12 and minimum Terraform version 1.3 which we already met in  this PR.
* Change Log: https://github.com/terraform-google-modules/terraform-google-sql-db/blob/master/CHANGELOG.md
* Upgrade to v20 Guide: https://github.com/terraform-google-modules/terraform-google-sql-db/blob/master/docs/upgrading_to_sql_db_20.0.0.md

##### terraform-google-modules/cloud-nat/google
* Versions:
  * Initial Version: ~> 5.0.0
  * Final Version: ~> 5.1.0
    * Notes:
      * No breaking changes
* Change Log: https://github.com/terraform-google-modules/terraform-google-cloud-nat/blob/master/CHANGELOG.md

### Tests

| Scenario | Provider | kubernetes_version   | order  | cadence   | Notes                                                 |
|----------|----------|----------------------|--------|-----------|-------------------------------------------------------|
| 1        | GCP      | v1.28.10-gke.1075000 | * | fast:2020 | Terraform on Host                                     | 
| 3        | GCP      | v1.28.10-gke.1075000 | * | fast:2020 | Terraform inside Docker container                     | 
| 3        | GCP      | v1.28.10-gke.1075000 | * | fast:2020 | Docker, created with 6.2.0 reapply infra with PR code | 