### PR TITLE
Adding depends_on for Netapp

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -316,4 +316,5 @@ module "google_netapp" {
   protocols          = var.netapp_protocols
   volume_path        = "${var.prefix}-${var.netapp_volume_path}"
   allowed_clients    = join(",", [local.gke_subnet_cidr, local.misc_subnet_cidr])
+  depends_on         = [ module.gke ]
 }


### PR DESCRIPTION
Change the priority of Netapp to start deployment after GKE has been fully deployed. This slows the entire deployment process but avoids a scenario where the GKE deployment is peering networks when the Netapp module attempts a similar peering operation.

This should resolve #231