### PR TITLE
docs: Correct database_flags syntax for Postgres servers (PSKD-1437)

### DIFF
--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -309,7 +309,7 @@ postgres_servers = {
     server_version                         = "15"
     availability_type                      = "ZONAL"
     ssl_enforcement_enabled                = true
-    database_flags                         = [{ name = "foo" value = "true"}, { name = "bar", value = "false"}]
+    database_flags                         = [{ name = "cloudsql.enable_pg_cron", value = "true"}, { name = "cloudsql.enable_pgaudit", value = "true"}]
   }
 }
 ```


### PR DESCRIPTION
### Changes
- Update the example postgres servers database_flags value to fix the invalid syntax and include two working example name/value pairs that can be used to set database_flags correctly.
### Tests
- After duplicating the error message noted in the internal ticket with the existing documentation format for database_flags, I updated the database_flags value for the default postgres server instance to use the format below that includes commas between name/value pairs and between each database_flags entry as required.
```
postgres_servers = {    
  default = {    
    database_flags         = [{ name = "cloudsql.enable_pg_cron", value = "true"}, { name = "cloudsql.enable_pgaudit", value = "true"}] 
  },    
}     
```
- I checked the created postgres server instance in the GCP console to verify that both the cloudsql.enable_pg_cron and cloudsql.enable_pgaudit database flags were set to "on" as expected.