### PR TITLE
feat(postgres): support edition param for PG 16+ with defaults

### DIFF
--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -278,6 +278,18 @@ Each server element, like `foo = {}`, can contain none, some, or all of the para
   - `edition` must be `"ENTERPRISE"`
   - `machine_type` must start with `"db-custom-"`
 
+*NOTE*: The default = {} elements is always required when creating external databases. This is the systems default database server.
+
+If you provide an empty block for default, the following default values will be used:
+terraform
+postgres_servers = {
+  default = {
+    server_version = "15"
+    edition        = "ENTERPRISE"
+    machine_type   = "db-custom-4-16384"
+  }
+}
+
 | Name | Description | Type | Default | Notes |
 | :--- | ---: | ---: | ---: | ---: |
 | machine_type| The machine type for the PostgreSQL server VMs" | string | "db-custom-4-16384" | Google Cloud Postgres supports only shared-core machine types such as db-f1-micro, and custom machine types such as db-custom-2-13312. Must match the PostgreSQL version requirements. |

--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -270,8 +270,8 @@ postgres_servers = {
 **NOTE**: The `default = {}` elements is always required when creating external databases. This is the systems default database server.
 
 Each server element, like `foo = {}`, can contain none, some, or all of the parameters listed below. If `machine_type` or `edition` are not provided, default values will be applied based on the `server_version`. For example:
-- If `server_version >= 16`, defaults to `edition = "ENTERPRISE_PLUS"` and `machine_type = "db-perf-optimized-N-8"`
-- If `server_version < 16`, defaults to `edition = "ENTERPRISE"` and `machine_type = "db-custom-2-7680"`
+- If `server_version >= 16`, defaults to `edition = "ENTERPRISE_PLUS"` and `machine_type = "db-perf-optimized-N-*"`
+- If `server_version < 16`, defaults to `edition = "ENTERPRISE"` and `machine_type = "db-custom-*"`
 
 | Name | Description | Type | Default | Notes |
 | :--- | ---: | ---: | ---: | ---: |

--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -298,6 +298,9 @@ Here is an example of the `postgres_servers` variable with the `default` server 
 postgres_servers = {
   default = {
     administrator_password       = "D0ntL00kTh1sWay"
+    server_version               = ""  # Specify PostgreSQL version here
+    machine_type                 = ""  # Specify the machine type here
+    edition                      = ""  # Specify the edition here (e.g., ENTERPRISE, ENTERPRISE_PLUS)
   },
   cds-postgres = {
     machine_type                           = "db-custom-4-16384"

--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -269,11 +269,14 @@ postgres_servers = {
 
 **NOTE**: The `default = {}` elements is always required when creating external databases. This is the systems default database server.
 
-Each server element, like `foo = {}`, can contain none, some, or all of the parameters listed below:
+Each server element, like `foo = {}`, can contain none, some, or all of the parameters listed below. If `machine_type` or `edition` are not provided, default values will be applied based on the `server_version`. For example:
+- If `server_version >= 16`, defaults to `edition = "ENTERPRISE_PLUS"` and `machine_type = "db-perf-optimized-N-8"`
+- If `server_version < 16`, defaults to `edition = "ENTERPRISE"` and `machine_type = "db-custom-2-7680"`
 
 | Name | Description | Type | Default | Notes |
 | :--- | ---: | ---: | ---: | ---: |
 | machine_type| The machine type for the PostgreSQL server VMs" | string | "db-custom-4-16384" | Google Cloud Postgres supports only shared-core machine types such as db-f1-micro, and custom machine types such as db-custom-2-13312. |
+| edition | Cloud SQL edition type | string | *(auto-determined)* | Accepts `"ENTERPRISE"` or `"ENTERPRISE_PLUS"`. Automatically set based on `server_version` if omitted. |
 | storage_gb | Minimum storage allowed for the PostgreSQL server | number | 128 | |
 | backups_enabled | Enables postgres backups | bool | true | |
 | backups_start_time | Start time for postgres backups | string | "21:00" | |

--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -269,14 +269,19 @@ postgres_servers = {
 
 **NOTE**: The `default = {}` elements is always required when creating external databases. This is the systems default database server.
 
-Each server element, like `foo = {}`, can contain none, some, or all of the parameters listed below. If `machine_type` or `edition` are not provided, default values will be applied based on the `server_version`. For example:
-- If `server_version >= 16`, defaults to `edition = "ENTERPRISE_PLUS"` and `machine_type = "db-perf-optimized-N-*"`
-- If `server_version < 16`, defaults to `edition = "ENTERPRISE"` and `machine_type = "db-custom-*"`
+Each server element, like `foo = {}`, can contain none, some, or all of the parameters listed below. The `machine_type` and `edition` parameters must be explicitly specified and will be validated based on the `server_version`:
+
+- For PostgreSQL 16+:
+  - `edition` must be `"ENTERPRISE_PLUS"`
+  - `machine_type` must start with `"db-perf-optimized-N-"`
+- For PostgreSQL < 16:
+  - `edition` must be `"ENTERPRISE"`
+  - `machine_type` must start with `"db-custom-"`
 
 | Name | Description | Type | Default | Notes |
 | :--- | ---: | ---: | ---: | ---: |
-| machine_type| The machine type for the PostgreSQL server VMs" | string | "db-custom-4-16384" | Google Cloud Postgres supports only shared-core machine types such as db-f1-micro, and custom machine types such as db-custom-2-13312. |
-| edition | Cloud SQL edition type | string | *(auto-determined)* | Accepts `"ENTERPRISE"` or `"ENTERPRISE_PLUS"`. Automatically set based on `server_version` if omitted. |
+| machine_type| The machine type for the PostgreSQL server VMs" | string | "db-custom-4-16384" | Google Cloud Postgres supports only shared-core machine types such as db-f1-micro, and custom machine types such as db-custom-2-13312. Must match the PostgreSQL version requirements. |
+| edition | Cloud SQL edition type | string | null | Must be `"ENTERPRISE"` for PostgreSQL < 16 or `"ENTERPRISE_PLUS"` for PostgreSQL 16+. |
 | storage_gb | Minimum storage allowed for the PostgreSQL server | number | 128 | |
 | backups_enabled | Enables postgres backups | bool | true | |
 | backups_start_time | Start time for postgres backups | string | "21:00" | |
@@ -292,18 +297,18 @@ Each server element, like `foo = {}`, can contain none, some, or all of the para
 
 Multiple SAS offerings require a second PostgreSQL instance referred to as SAS Common Data Store, or CDS PostgreSQL. For more information, see [Common Customizations](https://documentation.sas.com/?cdcId=itopscdc&cdcVersion=default&docsetId=dplyml0phy0dkr&docsetTarget=n08u2yg8tdkb4jn18u8zsi6yfv3d.htm#p0wkxxi9s38zbzn19ukjjaxsc0kl). A list of SAS offerings that require CDS PostgreSQL is provided in [SAS Common Data Store Requirements](https://documentation.sas.com/?cdcId=itopscdc&cdcVersion=default&docsetId=itopssr&docsetTarget=p05lfgkwib3zxbn1t6nyihexp12n.htm#n03wzanutmc6gon1val5fykas9aa). To create and configure an external CDS PostgreSQL instance in addition to the external platform PostgreSQL instance named `default`, specify `cds-postgres` as a second PostgreSQL instance, as shown in the example below.
 
-Here is an example of the `postgres_servers` variable with the `default` server entry overriding only the `administrator_password` parameter and the `cds-postgres` entry overriding all of the parameters:
+Here is an example of the `postgres_servers` variable with the `default` server entry and the `cds-postgres` entry, both with explicit edition and machine type configurations that match their PostgreSQL versions:
 
 ```terraform
 postgres_servers = {
   default = {
     administrator_password       = "D0ntL00kTh1sWay"
-    server_version               = ""  # Specify PostgreSQL version here
-    machine_type                 = ""  # Specify the machine type here
-    edition                      = ""  # Specify the edition here (e.g., ENTERPRISE, ENTERPRISE_PLUS)
+    server_version              = "16"  # PostgreSQL 16
+    machine_type                = "db-perf-optimized-N-8"  # Required for PostgreSQL 16+
+    edition                     = "ENTERPRISE_PLUS"  # Required for PostgreSQL 16+
   },
   cds-postgres = {
-    machine_type                           = "db-custom-4-16384"
+    machine_type                           = "db-custom-4-16384"  # Required for PostgreSQL < 16
     storage_gb                             = 128
     backups_enabled                        = true
     backups_start_time                     = "21:00"
@@ -312,7 +317,8 @@ postgres_servers = {
     backup_count                           = 7 # Number of backups to retain, not in days
     administrator_login                    = "cdsadmin"
     administrator_password                 = "my$up3rS3cretPassw0rd"
-    server_version                         = "15"
+    server_version                         = "15"  # PostgreSQL 15
+    edition                                = "ENTERPRISE"  # Required for PostgreSQL < 16
     availability_type                      = "ZONAL"
     ssl_enforcement_enabled                = true
     database_flags                         = [{ name = "cloudsql.enable_pg_cron", value = "true"}, { name = "cloudsql.enable_pgaudit", value = "true"}]

--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -293,7 +293,7 @@ postgres_servers = {
 | Name | Description | Type | Default | Notes |
 | :--- | ---: | ---: | ---: | ---: |
 | machine_type| The machine type for the PostgreSQL server VMs" | string | "db-custom-4-16384" | Google Cloud Postgres supports only shared-core machine types such as db-f1-micro, and custom machine types such as db-custom-2-13312. Must match the PostgreSQL version requirements. |
-| edition | Cloud SQL edition type | string | null | Must be `"ENTERPRISE"` for PostgreSQL < 16 or `"ENTERPRISE_PLUS"` for PostgreSQL 16+. |
+| edition | Cloud SQL edition type | string | "ENTERPRISE" | Must be `"ENTERPRISE"` for PostgreSQL < 16 or `"ENTERPRISE_PLUS"` for PostgreSQL 16+. |
 | storage_gb | Minimum storage allowed for the PostgreSQL server | number | 128 | |
 | backups_enabled | Enables postgres backups | bool | true | |
 | backups_start_time | Start time for postgres backups | string | "21:00" | |

--- a/examples/sample-input.tfvars
+++ b/examples/sample-input.tfvars
@@ -24,9 +24,9 @@ tags = {} # e.g., { "key1" = "value1", "key2" = "value2" }
 #                   block below.
 postgres_servers = {
   default = {
-    server_version = "16"              # Specify PostgreSQL version here
-    machine_type   = "db-custom-4-15360"  # Specify the machine type here
-    edition        = "ENTERPRISE_PLUS"  # Specify the edition here (e.g., ENTERPRISE, ENTERPRISE_PLUS)
+    server_version = ""              # Specify PostgreSQL version here
+    machine_type   = ""  # Specify the machine type here
+    edition        = ""  # Specify the edition here (e.g., ENTERPRISE, ENTERPRISE_PLUS)
   }
 },
 

--- a/examples/sample-input.tfvars
+++ b/examples/sample-input.tfvars
@@ -22,12 +22,10 @@ tags = {} # e.g., { "key1" = "value1", "key2" = "value2" }
 # Postgres config - By having this entry a database server is created. If you do not
 #                   need an external database server remove the 'postgres_servers'
 #                   block below.
+
 postgres_servers = {
-  default = {
-
-  }
+default = {},
 },
-
 
 # GKE config
 kubernetes_version         = "1.31"

--- a/examples/sample-input.tfvars
+++ b/examples/sample-input.tfvars
@@ -24,7 +24,7 @@ tags = {} # e.g., { "key1" = "value1", "key2" = "value2" }
 #                   block below.
 
 postgres_servers = {
-default = {},
+  default = {},
 },
 
 # GKE config

--- a/examples/sample-input.tfvars
+++ b/examples/sample-input.tfvars
@@ -24,9 +24,7 @@ tags = {} # e.g., { "key1" = "value1", "key2" = "value2" }
 #                   block below.
 postgres_servers = {
   default = {
-    server_version = ""              # Specify PostgreSQL version here
-    machine_type   = ""  # Specify the machine type here
-    edition        = ""  # Specify the edition here (e.g., ENTERPRISE, ENTERPRISE_PLUS)
+
   }
 },
 

--- a/examples/sample-input.tfvars
+++ b/examples/sample-input.tfvars
@@ -23,8 +23,13 @@ tags = {} # e.g., { "key1" = "value1", "key2" = "value2" }
 #                   need an external database server remove the 'postgres_servers'
 #                   block below.
 postgres_servers = {
-  default = {},
-}
+  default = {
+    server_version = "16"              # Specify PostgreSQL version here
+    machine_type   = "db-custom-4-15360"  # Specify the machine type here
+    edition        = "ENTERPRISE_PLUS"  # Specify the edition here (e.g., ENTERPRISE, ENTERPRISE_PLUS)
+  }
+},
+
 
 # GKE config
 kubernetes_version         = "1.31"

--- a/main.tf
+++ b/main.tf
@@ -256,21 +256,18 @@ module "postgresql" {
   deletion_protection = false
   module_depends_on   = [google_service_networking_connection.private_vpc_connection]
 
- edition = (
-  tonumber(each.value.server_version) >= 16 && each.value.edition != "ENTERPRISE_PLUS"
-) || (
-  tonumber(each.value.server_version) < 16 && each.value.edition != "ENTERPRISE"
-) ? (
-  tonumber(each.value.server_version) >= 16 ? "ENTERPRISE_PLUS" : "ENTERPRISE"
-) : each.value.edition
+  edition = tonumber(each.value.server_version) >= 16 ? "ENTERPRISE_PLUS" : "ENTERPRISE"
 
-tier = (
-  tonumber(each.value.server_version) >= 16 && !can(regex("^db-perf-optimized-", each.value.machine_type))
-) || (
-  tonumber(each.value.server_version) < 16 && !can(regex("^db-custom-", each.value.machine_type))
-) ? (
-  tonumber(each.value.server_version) >= 16 ? "db-perf-optimized-N-8" : "db-custom-4-16384"
-) : each.value.machine_type
+  // If semver is 16+ and machine_type is not db-perf-optimized-*, then use db-perf-optimized-N-8
+  // If semver is < 16 and machine_type is not db-custom-*, then use db-custom-4-16384
+  // Otherwise, use the machine_type from the input
+  tier = (
+    tonumber(each.value.server_version) >= 16 && !can(regex("^db-perf-optimized-", each.value.machine_type))
+  ) || (
+    tonumber(each.value.server_version) < 16 && !can(regex("^db-custom-", each.value.machine_type))
+  ) ? (
+    tonumber(each.value.server_version) >= 16 ? "db-perf-optimized-N-8" : "db-custom-4-16384"
+  ) : each.value.machine_type
 
   disk_size = each.value.storage_gb
 

--- a/main.tf
+++ b/main.tf
@@ -256,18 +256,8 @@ module "postgresql" {
   deletion_protection = false
   module_depends_on   = [google_service_networking_connection.private_vpc_connection]
 
-  edition = tonumber(each.value.server_version) >= 16 ? "ENTERPRISE_PLUS" : "ENTERPRISE"
-
-  // If semver is 16+ and machine_type is not db-perf-optimized-*, then use db-perf-optimized-N-8
-  // If semver is < 16 and machine_type is not db-custom-*, then use db-custom-4-16384
-  // Otherwise, use the machine_type from the input
-  tier = (
-    tonumber(each.value.server_version) >= 16 && !can(regex("^db-perf-optimized-", each.value.machine_type))
-  ) || (
-    tonumber(each.value.server_version) < 16 && !can(regex("^db-custom-", each.value.machine_type))
-  ) ? (
-    tonumber(each.value.server_version) >= 16 ? "db-perf-optimized-N-8" : "db-custom-4-16384"
-  ) : each.value.machine_type
+  edition = each.value.edition
+  tier    = each.value.machine_type
 
   disk_size = each.value.storage_gb
 

--- a/main.tf
+++ b/main.tf
@@ -269,7 +269,7 @@ tier = (
 ) || (
   tonumber(each.value.server_version) < 16 && !can(regex("^db-custom-", each.value.machine_type))
 ) ? (
-  tonumber(each.value.server_version) >= 16 ? "db-perf-optimized-N-8" : "db-custom-2-7680"
+  tonumber(each.value.server_version) >= 16 ? "db-perf-optimized-N-8" : "db-custom-4-16384"
 ) : each.value.machine_type
 
   disk_size = each.value.storage_gb

--- a/main.tf
+++ b/main.tf
@@ -256,7 +256,22 @@ module "postgresql" {
   deletion_protection = false
   module_depends_on   = [google_service_networking_connection.private_vpc_connection]
 
-  tier      = each.value.machine_type
+edition = (
+  tonumber(each.value.server_version) >= 16 && each.value.edition != "ENTERPRISE_PLUS"
+) || (
+  tonumber(each.value.server_version) < 16 && each.value.edition != "ENTERPRISE"
+) ? (
+  tonumber(each.value.server_version) >= 16 ? "ENTERPRISE_PLUS" : "ENTERPRISE"
+) : each.value.edition
+
+tier = (
+  tonumber(each.value.server_version) >= 16 && !can(regex("^db-perf-optimized-", each.value.machine_type))
+) || (
+  tonumber(each.value.server_version) < 16 && !can(regex("^db-custom-", each.value.machine_type))
+) ? (
+  tonumber(each.value.server_version) >= 16 ? "db-perf-optimized-N-8" : "db-custom-2-7680"
+) : each.value.machine_type
+
   disk_size = each.value.storage_gb
 
   enable_default_db        = false

--- a/main.tf
+++ b/main.tf
@@ -256,7 +256,7 @@ module "postgresql" {
   deletion_protection = false
   module_depends_on   = [google_service_networking_connection.private_vpc_connection]
 
-edition = (
+ edition = (
   tonumber(each.value.server_version) >= 16 && each.value.edition != "ENTERPRISE_PLUS"
 ) || (
   tonumber(each.value.server_version) < 16 && each.value.edition != "ENTERPRISE"

--- a/variables.tf
+++ b/variables.tf
@@ -383,7 +383,7 @@ variable "postgres_server_defaults" {
     availability_type                      = "ZONAL"
     ssl_enforcement_enabled                = true
     database_flags                         = []
-    edition                                = null
+    edition                                = "ENTERPRISE"
   }
 }
 
@@ -391,9 +391,7 @@ variable "postgres_server_defaults" {
 variable "postgres_servers" {
   description = "Map of PostgreSQL server objects"
   type        = any
-  default     = {
-    default = {}
-  }
+  default     = null
  
   # Checking for user provided "default" server
   validation {

--- a/variables.tf
+++ b/variables.tf
@@ -332,6 +332,7 @@ variable "node_pools" {
 #   Potentially we upgrade Terraform modules and versions and we bump our minimum required terraform version to be >1.3
 #   then at that time I can deprecate this variable and instead allow the user to configure node_locations per node pool.
 #   Refer to https://github.com/hashicorp/terraform/issues/29407#issuecomment-1150491619
+
 variable "nodepools_locations" {
   description = "GCP zone(s) where the additional node pools will allocate nodes in. Comma separated list."
   type        = string
@@ -382,7 +383,7 @@ variable "postgres_server_defaults" {
     availability_type                      = "ZONAL"
     ssl_enforcement_enabled                = true
     database_flags                         = []
-    edition                                = null
+    edition                                = "ENTERPRISE"
   }
 }
 
@@ -391,13 +392,9 @@ variable "postgres_servers" {
   description = "Map of PostgreSQL server objects"
   type        = any
   default     = {
-    default = {
-      server_version = "15"
-      edition        = "ENTERPRISE"
-      machine_type   = "db-custom-4-16384"
-    }
+    default = {}
   }
-
+ 
   # Checking for user provided "default" server
   validation {
     condition     = var.postgres_servers != null ? length(var.postgres_servers) != 0 ? contains(keys(var.postgres_servers), "default") : false : true
@@ -598,7 +595,6 @@ variable "gke_network_policy" {
   type        = bool
   default     = false
 }
-
 
 variable "create_static_kubeconfig" {
   description = "Allows the user to create a provider / service account based kube config file"

--- a/variables.tf
+++ b/variables.tf
@@ -362,14 +362,14 @@ variable "cluster_autoscaling_profile" {
   default     = "BALANCED"
 }
 
-# PostgreSQL
+# QL
 
 # Defaults
 variable "postgres_server_defaults" {
   description = "default values for a postgres server"
   type        = any
   default = {
-    machine_type                           = "db-custom-4-16384"
+    machPostgreSine_type                           = "db-custom-4-16384"
     storage_gb                             = 128
     backups_enabled                        = true
     backups_start_time                     = "21:00"
@@ -382,6 +382,7 @@ variable "postgres_server_defaults" {
     availability_type                      = "ZONAL"
     ssl_enforcement_enabled                = true
     database_flags                         = []
+    edition                                = null
   }
 }
 
@@ -589,4 +590,10 @@ variable "cluster_node_pool_mode" {
   description = "Flag for predefined cluster node configurations - Values : default, minimal"
   type        = string
   default     = "default"
+}
+
+variable "edition" {
+  description = "The edition of the PostgreSQL instance (ENTERPRISE or ENTERPRISE_PLUS)."
+  type        = string
+  default     = null
 }

--- a/variables.tf
+++ b/variables.tf
@@ -362,14 +362,14 @@ variable "cluster_autoscaling_profile" {
   default     = "BALANCED"
 }
 
-# QL
+# # PostgreSQL
 
 # Defaults
 variable "postgres_server_defaults" {
   description = "default values for a postgres server"
   type        = any
   default = {
-    machPostgreSine_type                           = "db-custom-4-16384"
+    machine_type                           = "db-custom-4-16384"
     storage_gb                             = 128
     backups_enabled                        = true
     backups_start_time                     = "21:00"
@@ -590,10 +590,4 @@ variable "cluster_node_pool_mode" {
   description = "Flag for predefined cluster node configurations - Values : default, minimal"
   type        = string
   default     = "default"
-}
-
-variable "edition" {
-  description = "The edition of the PostgreSQL instance (ENTERPRISE or ENTERPRISE_PLUS)."
-  type        = string
-  default     = null
 }

--- a/variables.tf
+++ b/variables.tf
@@ -383,7 +383,7 @@ variable "postgres_server_defaults" {
     availability_type                      = "ZONAL"
     ssl_enforcement_enabled                = true
     database_flags                         = []
-    edition                                = "ENTERPRISE"
+    edition                                = null
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -362,7 +362,7 @@ variable "cluster_autoscaling_profile" {
   default     = "BALANCED"
 }
 
-# # PostgreSQL
+# PostgreSQL
 
 # Defaults
 variable "postgres_server_defaults" {


### PR DESCRIPTION
**Summary**

- Refined Terraform logic for PostgreSQL provisioning to enforce version-specific validation and eliminate silent defaults.

**What Changed:**

- Strict validation added in variables.tf to ensure invalid combinations of server_version, edition, and machine_type fail fast with clear error messages.

- Removed silent defaulting behavior — values are no longer auto-corrected; misconfigurations are now surfaced to the user.

- Defaults are applied only when values are not explicitly set:

    Default: PostgreSQL 15 + ENTERPRISE + db-custom-4-16384

- Enforced version rules:

   PostgreSQL 16+ → requires ENTERPRISE_PLUS and db-perf-optimized-*

   PostgreSQL <16 → requires ENTERPRISE and db-custom-*

- Updated documentation in CONFIG-VARS.md to reflect these changes.

### ✅ PostgreSQL Server Creation Test Scenarios
| Test # | `server_version`       | `edition`        | `machine_type`              | Actual Outcome              |
|--------|--------------------------|------------------------|-------------------------------|-----------------------------
| 1      | default (15)      | -                | -                           | `db-custom-4-16384`, `"ENTERPRISE"`       |
| 2      | `"16"`            |`"ENTERPRISE"` | `"db-custom-4-16384"`       | Validation Error|
| 3     | `"16"`         |`"ENTERPRISE"`    | `"db-perf-optimized-N-4"` | Validation Error |
| 4   | `"16"`            |`"ENTERPRISE_PLUS"`    | `"db-perf-optimized-N-4"`      | `db-perf-optimized-N-4`, `"ENTERPRISE_PLUS"` |

