### PR TITLE
fix: update vm image to use Ubuntu 24.04

### DIFF
--- a/modules/google_vm/variables.tf
+++ b/modules/google_vm/variables.tf
@@ -65,7 +65,7 @@ variable "ssh_public_key" {
 variable "os_image" {
   description = "OS Image to configure the VM with"
   type        = string
-  default     = "ubuntu-os-cloud/ubuntu-2004-lts" # FAMILY/PROJECT glcoud compute images list
+  default     = "ubuntu-os-cloud/ubuntu-2404-lts-amd64" # FAMILY/PROJECT glcoud compute images list
 }
 
 

--- a/vms.tf
+++ b/vms.tf
@@ -29,7 +29,7 @@ module "nfs_server" {
   tags         = var.tags
 
   subnet   = local.subnet_names["misc"] // Name or self_link to subnet
-  os_image = "ubuntu-os-cloud/ubuntu-2004-lts"
+  os_image = "ubuntu-os-cloud/ubuntu-2404-lts-amd64"
 
   vm_admin       = var.nfs_vm_admin
   ssh_public_key = local.ssh_public_key
@@ -60,7 +60,7 @@ module "jump_server" {
   tags         = var.tags
 
   subnet   = local.subnet_names["misc"] // Name or self_link to subnet
-  os_image = "ubuntu-os-cloud/ubuntu-2004-lts"
+  os_image = "ubuntu-os-cloud/ubuntu-2404-lts-amd64"
 
   vm_admin       = var.jump_vm_admin
   ssh_public_key = local.ssh_public_key


### PR DESCRIPTION
Updating the VM image from Ubuntu 20.04 to Ubuntu 24.04. The old VM is EOL so we need to update it.

I was able to create a cluster using these changes. The VMs used the Ubuntu 24.04 image and my Viya installation worked as expected.