### PR TITLE
revert: "fix: update vm image to use Ubuntu 24.04 (PSKD-1841)"

### DIFF
--- a/modules/google_vm/variables.tf
+++ b/modules/google_vm/variables.tf
@@ -65,7 +65,7 @@ variable "ssh_public_key" {
 variable "os_image" {
   description = "OS Image to configure the VM with"
   type        = string
-  default     = "ubuntu-os-cloud/ubuntu-2404-lts-amd64" # FAMILY/PROJECT glcoud compute images list
+  default     = "ubuntu-os-cloud/ubuntu-2004-lts" # FAMILY/PROJECT glcoud compute images list
 }
 
 

--- a/vms.tf
+++ b/vms.tf
@@ -29,7 +29,7 @@ module "nfs_server" {
   tags         = var.tags
 
   subnet   = local.subnet_names["misc"] // Name or self_link to subnet
-  os_image = "ubuntu-os-cloud/ubuntu-2404-lts-amd64"
+  os_image = "ubuntu-os-cloud/ubuntu-2004-lts"
 
   vm_admin       = var.nfs_vm_admin
   ssh_public_key = local.ssh_public_key
@@ -60,7 +60,7 @@ module "jump_server" {
   tags         = var.tags
 
   subnet   = local.subnet_names["misc"] // Name or self_link to subnet
-  os_image = "ubuntu-os-cloud/ubuntu-2404-lts-amd64"
+  os_image = "ubuntu-os-cloud/ubuntu-2004-lts"
 
   vm_admin       = var.jump_vm_admin
   ssh_public_key = local.ssh_public_key


### PR DESCRIPTION
Reverts sassoftware/viya4-iac-gcp#278

There is potential for data loss if a `terraform apply` is run against an existing 20.04 NFS server. Reverting this until we have have a better workaround.