### PR TITLE
fix: update VMs to use Ubuntu 24.04

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -28,6 +28,7 @@ categories:
       - 'refactor'
       - 'revert'
       - 'style'
+      - 'revert'
 change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
 change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
 version-resolver:

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -14,5 +14,5 @@ jobs:
       - name: PR Conventional Commit Validation
         uses:  ytanikin/pr-conventional-commits@1.4.0
         with:
-          task_types: '["fix", "feat", "build", "chore", "ci", "docs", "style", "refactor", "perf", "test"]'
+          task_types: '["fix", "feat", "build", "chore", "ci", "docs", "style", "refactor", "perf", "test", "revert"]'
           custom_labels: '{"feat": "enhancement", "fix": "bug", "docs": "documentation", "ci": "CI/CD", "perf": "performance"}'

--- a/modules/google_vm/main.tf
+++ b/modules/google_vm/main.tf
@@ -48,6 +48,15 @@ resource "google_compute_instance" "google_vm" {
     }
   }
 
+  # Lifecycle settings for the resource
+  lifecycle {
+    ignore_changes = [
+      # Ignore changes to tags, e.g. because a management agent
+      # updates these based on some ruleset managed elsewhere.
+      boot_disk,
+    ]
+  }
+
   allow_stopping_for_update = true
 }
 

--- a/modules/google_vm/main.tf
+++ b/modules/google_vm/main.tf
@@ -51,8 +51,8 @@ resource "google_compute_instance" "google_vm" {
   # Lifecycle settings for the resource
   lifecycle {
     ignore_changes = [
-      # Ignore changes to tags, e.g. because a management agent
-      # updates these based on some ruleset managed elsewhere.
+      # Ignore changes to boot disk, as it could cause
+      # the VM to be recreated if the image is updated.
       boot_disk,
     ]
   }

--- a/modules/google_vm/variables.tf
+++ b/modules/google_vm/variables.tf
@@ -65,7 +65,7 @@ variable "ssh_public_key" {
 variable "os_image" {
   description = "OS Image to configure the VM with"
   type        = string
-  default     = "ubuntu-os-cloud/ubuntu-2004-lts" # FAMILY/PROJECT glcoud compute images list
+  default     = "ubuntu-os-cloud/ubuntu-2404-lts-amd64" # FAMILY/PROJECT glcoud compute images list
 }
 
 

--- a/test/helpers/helper_test.go
+++ b/test/helpers/helper_test.go
@@ -4,11 +4,12 @@
 package helpers
 
 import (
+	"testing"
+
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-07-01/compute"
 	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2020-10-01/resources"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 // TestRetrieveFromStruct tests the RetrieveFromStruct function, ensuring that values are correctly retrieved and
@@ -66,7 +67,7 @@ func TestRetrieveFromStruct(t *testing.T) {
 				ImageReference: &compute.ImageReference{
 					Offer:     to.StringPtr("0001-com-ubuntu-server-focal"),
 					Publisher: to.StringPtr("Canonical"),
-					Sku:       to.StringPtr("20_04-lts"),
+					Sku:       to.StringPtr("24_04-lts-amd64"),
 					Version:   to.StringPtr("latest"),
 				},
 			},
@@ -110,7 +111,7 @@ func TestRetrieveFromStruct(t *testing.T) {
 	publisher := RetrieveFromStruct(nfsVM, "VirtualMachineProperties", "StorageProfile", "ImageReference", "Publisher")()
 	assert.Equal(t, "Canonical", publisher)
 	sku := RetrieveFromStruct(nfsVM, "VirtualMachineProperties", "StorageProfile", "ImageReference", "Sku")()
-	assert.Equal(t, "20_04-lts", sku)
+	assert.Equal(t, "24_04-lts-amd64", sku)
 	version := RetrieveFromStruct(nfsVM, "VirtualMachineProperties", "StorageProfile", "ImageReference", "Version")()
 	assert.Equal(t, "latest", version)
 }

--- a/vms.tf
+++ b/vms.tf
@@ -29,7 +29,7 @@ module "nfs_server" {
   tags         = var.tags
 
   subnet   = local.subnet_names["misc"] // Name or self_link to subnet
-  os_image = "ubuntu-os-cloud/ubuntu-2004-lts"
+  os_image = "ubuntu-os-cloud/ubuntu-2404-lts-amd64"
 
   vm_admin       = var.nfs_vm_admin
   ssh_public_key = local.ssh_public_key
@@ -60,7 +60,7 @@ module "jump_server" {
   tags         = var.tags
 
   subnet   = local.subnet_names["misc"] // Name or self_link to subnet
-  os_image = "ubuntu-os-cloud/ubuntu-2004-lts"
+  os_image = "ubuntu-os-cloud/ubuntu-2404-lts-amd64"
 
   vm_admin       = var.jump_vm_admin
   ssh_public_key = local.ssh_public_key


### PR DESCRIPTION
Follow up to #278 and #279. This updates the VM image used for the NFS server and Jump VM to Ubuntu 24.04 LTS. The old 20.04 image is EOL and no longer accessible.

This change respects any existing VM and will not delete/recreate it.

I've also updated the associated test file and added the `revert` conventional commit to the workflow.