### PR TITLE
feat: add google cloud marketplace default label to provider block

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -15,7 +15,7 @@ provider "google" {
   credentials = var.service_account_keyfile != null ? can(file(var.service_account_keyfile)) ? file(var.service_account_keyfile) : null : null
   project     = var.project
   default_labels = {
-    goog-partner-solution = "isol_plb32_0014m00001h35jvqaa_brawiwxrvplbhqu7gmnkfhclzx3uqx5o"
+    goog-partner-solution = "isol_plb32_0014m00001h35jvqaa_qxe2gvexrm4ooh7tfz7tvel7ffjdujvk"
   }
 }
 


### PR DESCRIPTION
This commit adds the required default_labels to the google provider in main.tf, allowing Google Cloud to track Marketplace software installation in the tenant.