### PR TITLE
feat: add support for singlestore on gcp and terraform output variables. (PSCLOUD-92, PSCLOUD-161)

### DIFF
--- a/examples/sample-input-singlestore.tfvars
+++ b/examples/sample-input-singlestore.tfvars
@@ -1,0 +1,112 @@
+# !NOTE! - These are only a subset of CONFIG-VARS.md provided for sample.
+# Customize this file to add any variables from 'CONFIG-VARS.md' that you want 
+# to change their default values.
+
+# ****************  REQUIRED VARIABLES  ****************
+# These required variables' values MUST be provided by the User
+prefix                  = "<prefix-value>"
+location                = "<gcp-zone-or-region>" # e.g., "us-east1-b"
+project                 = "<gcp-project-id>"
+service_account_keyfile = "<service-account-json-file>"
+#
+# ****************  REQUIRED VARIABLES  ****************
+
+# ****************  RECOMMENDED VARIABLES  ****************
+default_public_access_cidrs = [] # e.g., ["123.45.6.89/32"]
+ssh_public_key              = "~/.ssh/id_rsa.pub"
+# ****************  RECOMMENDED VARIABLES  ****************
+
+# add labels to the created resources
+tags = {} # e.g., { "key1" = "value1", "key2" = "value2" }
+
+# Postgres config - By having this entry a database server is created. If you do not
+#                   need an external database server remove the 'postgres_servers'
+#                   block below.
+postgres_servers = {
+  default = {},
+}
+
+# GKE config
+kubernetes_version         = "1.32"
+default_nodepool_min_nodes = 2
+default_nodepool_vm_type   = "n2-highmem-8"
+
+# Node Pools config
+node_pools = {
+  cas = {
+    "vm_type"      = "n2-highmem-16"
+    "os_disk_size" = 200
+    "min_nodes"    = 1
+    "max_nodes"    = 5
+    "node_taints"  = ["workload.sas.com/class=cas:NoSchedule"]
+    "node_labels" = {
+      "workload.sas.com/class" = "cas"
+    }
+    "local_ssd_count"   = 2
+    "accelerator_count" = 0
+    "accelerator_type"  = ""
+  },
+  compute = {
+    "vm_type"      = "n2-highmem-4"
+    "os_disk_size" = 200
+    "min_nodes"    = 1
+    "max_nodes"    = 5
+    "node_taints"  = ["workload.sas.com/class=compute:NoSchedule"]
+    "node_labels" = {
+      "workload.sas.com/class"        = "compute"
+      "launcher.sas.com/prepullImage" = "sas-programming-environment"
+    }
+    "local_ssd_count"   = 1
+    "accelerator_count" = 0
+    "accelerator_type"  = ""
+  },
+  stateless = {
+    "vm_type"      = "n2-highmem-4"
+    "os_disk_size" = 200
+    "min_nodes"    = 1
+    "max_nodes"    = 5
+    "node_taints"  = ["workload.sas.com/class=stateless:NoSchedule"]
+    "node_labels" = {
+      "workload.sas.com/class" = "stateless"
+    }
+    "local_ssd_count"   = 0
+    "accelerator_count" = 0
+    "accelerator_type"  = ""
+  },
+  stateful = {
+    "vm_type"      = "n2-highmem-4"
+    "os_disk_size" = 200
+    "min_nodes"    = 1
+    "max_nodes"    = 3
+    "node_taints"  = ["workload.sas.com/class=stateful:NoSchedule"]
+    "node_labels" = {
+      "workload.sas.com/class" = "stateful"
+    }
+    "local_ssd_count"   = 0
+    "accelerator_count" = 0
+    "accelerator_type"  = ""
+  },
+  singlestore = {
+    "vm_type" = "n2-highmem-16"
+    "os_disk_size" = 200
+    "min_nodes" = 0
+    "max_nodes" = 7
+    "node_taints" = ["workload.sas.com/class=singlestore:NoSchedule"]
+    "node_labels" = {
+      "workload.sas.com/class" = "singlestore"
+    }
+    "local_ssd_count"   = 2
+    "accelerator_count" = 0
+    "accelerator_type"  = ""
+  }
+}
+# Jump Box
+create_jump_public_ip = true
+jump_vm_admin         = "jumpuser"
+
+# Storage for Viya Compute Services
+# Supported storage_type values
+#    "standard" - Custom managed NFS Server VM and disks
+#    "ha"       - Google Filestore  or Google NetApp Volumes
+storage_type = "ha"
+storage_type_backend = "filestore"  # "filestore" is the default, use "netapp" to create Google NetApp Volumes

--- a/outputs.tf
+++ b/outputs.tf
@@ -108,3 +108,12 @@ output "cluster_api_mode" {
 output "gke_pod_subnet_cidr" {
   value = var.gke_pod_subnet_cidr
 }
+
+output "storage_type_backend" {
+  value       = var.storage_type_backend
+  description = "If storage_type=standard the default is nfs. If storage_type=ha the default is filestore"
+}
+
+output "netapp_volume_path" {
+  value       = var.storage_type_backend == "netapp" ? var.netapp_volume_path : "export"
+}


### PR DESCRIPTION
## SingleStore Support for GCP (PSCLOUD-92)
- Added example .tfvars configuration for SingleStore deployment.
- Provided a ready-to-use configuration template to simplify setup.
## Output variable support (PSCLOUD-161)
- Updated output.tf to include storage_type_backend and netapp_volume_path variables for flexibility.