### PR TITLE
chore: updated hashicorp/google and hashicorp/google-beta from 6.28.0 to 7.8.0 along with constraints.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -97,7 +97,7 @@ data "google_container_engine_versions" "gke-version" {
 
 module "gke" {
   source                        = "terraform-google-modules/kubernetes-engine/google//modules/private-cluster"
-  version                       = "~> 36.2.0"
+  version                       = "~> 40.0"
   project_id                    = var.project
   name                          = "${var.prefix}-gke"
   region                        = local.region
@@ -247,7 +247,7 @@ resource "local_file" "kubeconfig" {
 # Module Registry - https://registry.terraform.io/modules/GoogleCloudPlatform/sql-db/google/12.0.0/submodules/postgresql
 module "postgresql" {
   source     = "GoogleCloudPlatform/sql-db/google//modules/postgresql"
-  version    = "~> 25.2.2"
+  version    = "~> 27.0"
   project_id = var.project
 
   for_each = local.postgres_servers != null ? length(local.postgres_servers) != 0 ? local.postgres_servers : {} : {}
@@ -301,7 +301,7 @@ module "postgresql" {
 
 module "sql_proxy_sa" {
   source        = "terraform-google-modules/service-accounts/google"
-  version       = "~> 4.4.0"
+  version       = "~> 4.6"
   count         = var.postgres_servers != null ? length(var.postgres_servers) != 0 ? 1 : 0 : 0
   project_id    = var.project
   prefix        = var.prefix

--- a/modules/google_vm/main.tf
+++ b/modules/google_vm/main.tf
@@ -3,7 +3,7 @@
 
 module "address" {
   source       = "terraform-google-modules/address/google"
-  version      = "~> 4.1.0"
+  version      = "~> 5.0"
   project_id   = var.project
   region       = var.region
   address_type = "EXTERNAL"

--- a/network.tf
+++ b/network.tf
@@ -11,7 +11,7 @@ data "google_compute_address" "nat_address" {
 module "nat_address" {
   count        = length(var.nat_address_name) == 0 ? 1 : 0
   source       = "terraform-google-modules/address/google"
-  version      = "~> 4.1.0"
+  version      = "~> 5.0"
   project_id   = var.project
   region       = local.region
   address_type = "EXTERNAL"
@@ -23,7 +23,7 @@ module "nat_address" {
 module "cloud_nat" {
   count         = length(var.nat_address_name) == 0 ? 1 : 0
   source        = "terraform-google-modules/cloud-nat/google"
-  version       = "~> 5.3.0"
+  version       = "~> 6.0"
   project_id    = var.project
   name          = "${var.prefix}-cloud-nat"
   region        = local.region

--- a/versions.tf
+++ b/versions.tf
@@ -7,11 +7,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "7.5.0"
+      version = "7.8.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "7.5.0"
+      version = "7.8.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/versions.tf
+++ b/versions.tf
@@ -7,11 +7,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "6.28.0"
+      version = "7.5.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "6.28.0"
+      version = "7.5.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"


### PR DESCRIPTION
A direct provider-only version bump was failing during Docker build because several dependent Terraform modules still had provider constraints like < 7.0.0. To resolve the constraint conflict, the related modules were also upgraded:
kubernetes-engine: ~> 36.2.0 → ~> 40.0
sql-db: ~> 25.2.2 → ~> 27.0
service-accounts: ~> 4.4.0 → ~> 4.6
cloud-nat: ~> 5.3.0 → ~> 6.0
address: ~> 4.1.0 → ~> 5.0

This is required to make the Google provider 7.x upgrade compatible with all module constraints