### PR TITLE
feat: add dns abstraction for netapp cross-zone replication (czr) endpoint (PSCLOUD-1053)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This project contains Terraform scripts to provision Google Cloud infrastructure
   >- Managed Google Kubernetes Engine (GKE) cluster
   >- System and User GKE Node pools with required Labels and Taints
   >- Infrastructure to deploy SAS Viya platform CAS in SMP or MPP mode
-  >- Shared Storage options for SAS Viya platform -  Google Filestore (ha), Google NetApp Volumes (ha) or NFS Server (standard)
+  >- Shared Storage options for SAS Viya platform - NFS Server or Google Filestore (`storage_type="standard"`) and Google NetApp Volumes (`storage_type="ha"`)
   >- Google Cloud SQL for PostgreSQL instance, optional
 
 [<img src="./docs/images/viya4-iac-gcp-diag.png" alt="Architecture Diagram" width="750"/>](./docs/images/viya4-iac-gcp-diag.png?raw=true)

--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -251,6 +251,9 @@ When `storage_type=ha` and `storage_type_backend=netapp` are specified, [Google 
 | netapp_protocols | The target volume protocol expressed as a list. | list(string) | ["NFSV3"] | Each value may be one of: NFSV3, NFSV4, SMB. Currently, only NFSV3 is supported by SAS Viya Platform. |
 | netapp_capacity_gib | Capacity of the storage pool (in GiB). Storage Pool capacity specified must be between 2048 GiB and 10485760 GiB. | string | "2048" | |
 | netapp_volume_path | A unique file path for the volume. Used when creating mount targets. Needs to be unique per location.| string | | |
+| enable_netapp_dns | Enable Private DNS zone and A record for zone-redundant NetApp endpoint. Provides stable DNS hostname for Cross-Zone Replication failover scenarios. | bool | false | Only applicable for multi-zone HA deployments with NetApp Volumes. When enabled, the `rwx_filestore_endpoint` output will return a DNS hostname instead of an IP address. |
+| netapp_dns_zone_name | Name for the Private DNS zone for NetApp endpoint. | string | "netapp-private.internal" | Only used when `enable_netapp_dns=true`. |
+| netapp_dns_hostname | DNS hostname for the NetApp volume endpoint. | string | "netapp-volume" | Only used when `enable_netapp_dns=true`. Must be a valid DNS hostname (lowercase alphanumeric and hyphens only). |
 
 ### Google NetApp Volumes — Zone Redundancy Limitations
 

--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -221,6 +221,16 @@ stateful = {
 | storage_type | Type of Storage. Valid Values: "standard", "ha" | string | "standard" | "standard" creates an NFS server VM or Google Filestore instance. "ha" provisions Google NetApp Volumes — supports zone redundancy when using `FLEX` service level. See [zone redundancy limitations](#google-netapp-volumes--zone-redundancy-limitations). |
 | storage_type_backend | The storage backend for the chosen `storage_type`. | string | If `storage_type=standard` the default is "nfs";<br>If `storage_type=ha` the default is "netapp" | Valid Values: "nfs" or "filestore" if `storage_type=standard`; "netapp" if `storage_type=ha`. |
 
+### Storage Backend Compatibility Matrix
+
+| `storage_type` | `storage_type_backend` | Result |
+| :--- | :--- | :--- |
+| `standard` | `nfs` (default) | Provisions NFS server VM |
+| `standard` | `filestore` | Provisions Google Filestore |
+| `ha` | `netapp` (required) | Provisions Google NetApp Volumes |
+
+Any other `storage_type` + `storage_type_backend` combination is invalid and fails validation.
+
 ### For `storage_type=standard` only (NFS server VM)
 
 | Name | Description | Type | Default | Notes |

--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -254,6 +254,7 @@ When `storage_type=ha` and `storage_type_backend=netapp` are specified, [Google 
 | enable_netapp_dns | Enable Private DNS zone and A record for zone-redundant NetApp endpoint. Provides stable DNS hostname for Cross-Zone Replication failover scenarios. | bool | false | Only applicable for multi-zone HA deployments with NetApp Volumes. When enabled, the `rwx_filestore_endpoint` output will return a DNS hostname instead of an IP address. |
 | netapp_dns_zone_name | Name for the Private DNS zone for NetApp endpoint. | string | "netapp-private.internal" | Only used when `enable_netapp_dns=true`. |
 | netapp_dns_hostname | DNS hostname for the NetApp volume endpoint. | string | "netapp-volume" | Only used when `enable_netapp_dns=true`. Must be a valid DNS hostname (lowercase alphanumeric and hyphens only). |
+| netapp_dns_record_ttl | TTL in seconds for the DNS A record. | number | 300 | Only used when `enable_netapp_dns=true`. Must be between 60 and 86400 seconds (1 minute to 1 day). |
 
 ### Google NetApp Volumes — Zone Redundancy Limitations
 

--- a/docs/CONFIG-VARS.md
+++ b/docs/CONFIG-VARS.md
@@ -69,7 +69,7 @@ You can use `default_public_access_cidrs` to set a default range for all created
 | gke_service_subnet_cidr | Secondary address space in the GKE subnet for Kubernetes Services | string | "10.1.0.0/22" | This variable is ignored when `subnet_names` is set (aka bring your own subnets) |
 | gke_control_plane_subnet_cidr |  Address space for the hosted primary subnet | string | "10.2.0.0/28" | When providing your own subnets (by setting `subnet_names` make sure your subnets do not overlap this range  |
 | misc_subnet_cidr | Address space for the the auxiliary resources (Jump VM and optionally NFS VM) subnet | string | "192.168.2.0/24" | This variable is ignored when `subnet_names` is set (aka bring your own subnet) |
-| filestore_subnet_cidr | Address space for Google Filestore subnet | string | "192.168.3.0/29" | Needs to be at least a /29 range. Only used when `storage_type="ha"` |
+| filestore_subnet_cidr | Address space for Google Filestore subnet | string | "192.168.3.0/29" | Needs to be at least a /29 range. Only used when `storage_type="standard"` and `storage_type_backend="filestore"`. |
 | database_subnet_cidr | Address space for Google Cloud SQL Postgres subnet | string | "192.168.4.0/23" | Only used with external postgres |
 | netapp_subnet_cidr | Address space for Google Cloud NetApp Volumes subnet | string | "192.168.6.0/24" | Needs to be at least a /24 range. Only used when `storage_type="ha"`. Default changed from 192.168.5.0/24 to avoid overlap with database_subnet_cidr (192.168.4.0/23). |
 | gke_network_policy | Sets up network policy to be used with GKE CNI. Network policy allows us to control the traffic flow between pods. | string | false | Supported values are true (calico) and false (kubenet). |
@@ -219,7 +219,7 @@ stateful = {
 | Name | Description | Type | Default | Notes |
 | :--- | ---: | ---: | ---: | ---: |
 | storage_type | Type of Storage. Valid Values: "standard", "ha" | string | "standard" | "standard" creates an NFS server VM or Google Filestore instance. "ha" provisions Google NetApp Volumes — supports zone redundancy when using `FLEX` service level. See [zone redundancy limitations](#google-netapp-volumes--zone-redundancy-limitations). |
-| storage_type_backend | The storage backend for the chosen `storage_type`. | string | If `storage_type=standard` the default is "nfs";<br>If `storage_type=ha` the default is "netapp" | Valid Values: "nfs" or "filestore" if `storage_type=standard`; "netapp" if `storage_type=ha`. |
+| storage_type_backend | The storage backend for the chosen `storage_type`. | string | `"nfs"` | Valid Values: `"nfs"` or `"filestore"` if `storage_type="standard"`; `"netapp"` if `storage_type="ha"`. For `storage_type="ha"`, set `storage_type_backend="netapp"` explicitly. |
 
 ### Storage Backend Compatibility Matrix
 
@@ -250,7 +250,7 @@ Any other `storage_type` + `storage_type_backend` combination is invalid and fai
 
 ### For `storage_type=ha` with Google NetApp Volumes
 
-When `storage_type=ha` and `storage_type_backend=netapp` are specified, [Google NetApp Volumes](https://cloud.google.com/netapp/volumes/docs/discover/overview) service is created. Before using this storage option,
+When `storage_type=ha`, configure `storage_type_backend=netapp` to satisfy input validation and provision [Google NetApp Volumes](https://cloud.google.com/netapp/volumes/docs/discover/overview). Before using this storage option,
 - Enable the Google Cloud NetApp Volumes API for your project, see how to enable [here](https://cloud.google.com/netapp/volumes/docs/get-started/configure-access/initiate-console-settings#enable_the_api).
 - Grant access to NetApp Volumes operations by granting IAM roles to users. The two predefined roles are `roles/netapp.admin` and `roles/netapp.viewer`. You can assign these roles to specific users or service accounts.
 - NetApp Volumes is available in several regions. For details about region availability, see [NetApp Volumes locations](https://cloud.google.com/netapp/volumes/docs/locations).

--- a/docs/user/APIServices.md
+++ b/docs/user/APIServices.md
@@ -7,6 +7,7 @@ Make sure your Google Cloud Project has at least the following API Services enab
 | `container.googleapis.com` | [Kubernetes Engine API](https://console.cloud.google.com/apis/library/container.googleapis.com) ||
 | `compute.googleapis.com`| [Compute Engine API](https://console.cloud.google.com/apis/library/compute.googleapis.com) ||
 | `file.googleapis.com` | [Cloud Filestore API](https://console.cloud.google.com/apis/library/file.googleapis.com) | Needed for `storage_type="ha"` |
+| `dns.googleapis.com` | [Cloud DNS API](https://console.cloud.google.com/apis/library/dns.googleapis.com) | Needed when `enable_netapp_dns=true` for NetApp Cross-Zone Replication DNS abstraction |
 | `sqladmin.googleapis.com`| [Cloud SQL Admin API](https://console.cloud.google.com/apis/library/sqladmin.googleapis.com) | Needed when creating an [SQL Postgres instance](../CONFIG-VARS.md#postgres-servers) |
 | `servicenetworking.googleapis.com`| [Service Networking API](https://console.cloud.google.com/apis/library/servicenetworking.googleapis.com) | Needed when creating an [SQL Postgres instance](../CONFIG-VARS.md#postgres-servers) |
 | `cloudresourcemanager.googleapis.com`| [Cloud Resource Manager API](https://console.cloud.google.com/apis/library/cloudresourcemanager.googleapis.com) | Needed if you create an [SQL Postgres instance](../CONFIG-VARS.md#postgres-servers) |

--- a/docs/user/APIServices.md
+++ b/docs/user/APIServices.md
@@ -6,7 +6,8 @@ Make sure your Google Cloud Project has at least the following API Services enab
 | :--- | :--- | :---  |
 | `container.googleapis.com` | [Kubernetes Engine API](https://console.cloud.google.com/apis/library/container.googleapis.com) ||
 | `compute.googleapis.com`| [Compute Engine API](https://console.cloud.google.com/apis/library/compute.googleapis.com) ||
-| `file.googleapis.com` | [Cloud Filestore API](https://console.cloud.google.com/apis/library/file.googleapis.com) | Needed for `storage_type="ha"` |
+| `file.googleapis.com` | [Cloud Filestore API](https://console.cloud.google.com/apis/library/file.googleapis.com) | Needed for `storage_type="standard"` with `storage_type_backend="filestore"` |
+| `netapp.googleapis.com` | [Cloud NetApp API](https://console.cloud.google.com/apis/library/netapp.googleapis.com) | Needed for `storage_type="ha"` with `storage_type_backend="netapp"` |
 | `dns.googleapis.com` | [Cloud DNS API](https://console.cloud.google.com/apis/library/dns.googleapis.com) | Needed when `enable_netapp_dns=true` for NetApp Cross-Zone Replication DNS abstraction |
 | `sqladmin.googleapis.com`| [Cloud SQL Admin API](https://console.cloud.google.com/apis/library/sqladmin.googleapis.com) | Needed when creating an [SQL Postgres instance](../CONFIG-VARS.md#postgres-servers) |
 | `servicenetworking.googleapis.com`| [Service Networking API](https://console.cloud.google.com/apis/library/servicenetworking.googleapis.com) | Needed when creating an [SQL Postgres instance](../CONFIG-VARS.md#postgres-servers) |

--- a/docs/user/Multi-ZoneDeploymentGuide.md
+++ b/docs/user/Multi-ZoneDeploymentGuide.md
@@ -1,0 +1,256 @@
+# Multi-Zone Deployment Guide
+
+## Table of Contents
+
+- [Overview](#overview)
+- [GKE Multi-Zone Configuration](#gke-multi-zone-configuration)
+	- [Configuration Variables](#configuration-variables)
+	- [Usage Example](#usage-example)
+	- [Validation](#validation)
+- [Google NetApp Volumes Cross-Zone Replication](#google-netapp-volumes-cross-zone-replication)
+	- [Configuration Variables](#configuration-variables-1)
+	- [Usage Example](#usage-example-1)
+	- [DNS-Based Failover Resilience](#dns-based-failover-resilience)
+	- [Validation](#validation-1)
+- [Complete Multi-Zone Example](#complete-multi-zone-example)
+- [Deployment Scenarios](#deployment-scenarios)
+- [Limitations Summary](#limitations-summary)
+- [Backward Compatibility](#backward-compatibility)
+- [Default Values](#default-values)
+- [Cost Considerations](#cost-considerations)
+- [Recommended Architecture](#recommended-architecture)
+- [Best Practices for GCP Multi-Zone](#best-practices-for-gcp-multi-zone)
+- [References](#references)
+
+## Overview
+
+This guide describes how to deploy SAS Viya on Google Cloud Platform (GCP) in a multi-zone configuration using the current `viya4-iac-gcp` implementation.
+
+The GCP multizone model in this repository is built around three pieces:
+
+- **GKE node placement** via `default_nodepool_locations` and `nodepools_locations`
+- **Regional control plane** via `regional`
+- **Google NetApp Volumes DNS abstraction** for zone-redundant storage via `enable_netapp_dns`
+
+All multizone behavior in this repository is opt-in and uses safe defaults for single-zone deployments.
+
+### What Gets Protected
+
+| Component | Multizone Behavior | Outcome |
+| :--- | :--- | :--- |
+| GKE node pools | Nodes spread across multiple zones | Pods can reschedule if a zone fails |
+| GKE control plane | Regional control plane when `regional = true` | Better control-plane resilience |
+| Google NetApp Volumes | Zone-redundant storage with optional DNS abstraction | Stable endpoint for failover scenarios |
+| Shared storage endpoint | DNS hostname when enabled | Avoids depending on a static IP |
+
+### Multizone Rules in This Repository
+
+The repository treats a deployment as multizone when `default_nodepool_locations` contains more than one zone.
+
+Relevant implementation details:
+
+- `modules/google_netapp/locals.tf` sets `local.is_multizone = length(split(",", var.default_nodepool_locations)) > 1`
+- `modules/google_netapp/main.tf` creates DNS resources only when `enable_netapp_dns = true` **and** `local.is_multizone = true`
+- `vms.tf` uses the NetApp module `endpoint` output for the shared storage endpoint
+- `outputs.tf` exposes `rwx_filestore_endpoint` as a DNS hostname when DNS abstraction is enabled
+
+## GKE Multi-Zone Configuration
+
+Enable multizone GKE placement by setting the control plane and node pool zone inputs.
+
+### Configuration Variables
+
+| Name | Description | Type | Default | Notes |
+| :--- | ---: | ---: | ---: | --- |
+| `regional` | Use a regional or zonal GKE control plane | bool | `false` | Set `true` for a regional control plane |
+| `default_nodepool_locations` | Comma-separated list of zones for the default node pool | string | `""` | Use 2 or more zones to enable multizone behavior |
+| `nodepools_locations` | Comma-separated list of zones for additional node pools | string | `""` | Optional global fallback for additional node pools |
+
+### Usage Example
+
+```hcl
+regional = true
+
+default_nodepool_locations = "us-east1-b,us-east1-c,us-east1-d"
+nodepools_locations        = "us-east1-b,us-east1-c,us-east1-d"
+```
+
+### Validation
+
+The configuration is considered multizone when `default_nodepool_locations` contains multiple zones.
+
+Validation expectations:
+
+- `default_nodepool_locations` must contain at least two zones for multizone behavior
+- `regional = true` is recommended for a regional control plane in multizone deployments
+- Additional node pools may use `nodepools_locations` as a global fallback
+
+## Google NetApp Volumes Cross-Zone Replication
+
+When `storage_type = "ha"`, the repository provisions Google NetApp Volumes for RWX storage. When `enable_netapp_dns = true` and multizone is detected, the module creates a Private Cloud DNS zone and A record for the shared storage endpoint.
+
+### Configuration Variables
+
+| Name | Description | Type | Default | Notes |
+| :--- | ---: | ---: | ---: | --- |
+| `storage_type` | Storage type used by the deployment | string | `standard` | Set `ha` to provision Google NetApp Volumes |
+| `netapp_service_level` | NetApp storage pool service level | string | `PREMIUM` | Use `FLEX` for zone-redundant pools |
+| `enable_netapp_dns` | Enable Private DNS zone and A record for the NetApp endpoint | bool | `false` | Only applies when the deployment is multizone |
+| `netapp_dns_zone_name` | Private DNS zone name for NetApp | string | `netapp-private.internal` | Used only when `enable_netapp_dns = true` |
+| `netapp_dns_hostname` | Hostname used for the NetApp endpoint | string | `netapp-volume` | Used only when `enable_netapp_dns = true` |
+| `netapp_dns_record_ttl` | TTL for the DNS A record | number | `300` | Used only when `enable_netapp_dns = true`; valid range is `60` to `86400` |
+
+### Usage Example
+
+```hcl
+storage_type         = "ha"
+netapp_service_level = "FLEX"
+
+enable_netapp_dns     = true
+netapp_dns_zone_name  = "netapp.internal"
+netapp_dns_hostname   = "netapp-volume"
+netapp_dns_record_ttl = 300
+```
+
+### DNS-Based Failover Resilience
+
+When `enable_netapp_dns = true` and the deployment is multizone:
+
+- A private Cloud DNS zone is created
+- An A record is created for the NetApp endpoint
+- `rwx_filestore_endpoint` returns a DNS hostname instead of a raw IP
+- `netapp_dns_record_ttl` controls the DNS TTL
+
+This is intended to simplify failover handling for zone-redundant NetApp deployments.
+
+### Validation
+
+The repository validates the following multizone behavior:
+
+- `enable_netapp_dns` only creates DNS resources when multizone is detected
+- `netapp_dns_hostname` must be a valid DNS hostname
+- `netapp_dns_record_ttl` must be between `60` and `86400`
+- `netapp_service_level = "FLEX"` is required for zone-redundant NetApp storage pools
+
+## Complete Multi-Zone Example
+
+A complete starter example is available in:
+
+- `examples/sample-input-multizone.tfvars`
+
+That example includes:
+
+- Regional GKE control plane configuration
+- Multi-zone node placement
+- Google NetApp Volumes configuration
+- DNS abstraction for the shared storage endpoint
+
+## Deployment Scenarios
+
+### Scenario 1: Multizone GKE Only
+
+Use this when you want GKE nodes spread across zones but do not need NetApp DNS abstraction.
+
+Suggested settings:
+
+- `regional = true`
+- `default_nodepool_locations` with 2+ zones
+- `enable_netapp_dns = false`
+
+### Scenario 2: Full Multizone with NetApp DNS
+
+Use this when you want multizone GKE plus a stable storage endpoint for zone-redundant NetApp volumes.
+
+Suggested settings:
+
+- `regional = true`
+- `default_nodepool_locations` with 2+ zones
+- `storage_type = "ha"`
+- `netapp_service_level = "FLEX"`
+- `enable_netapp_dns = true`
+
+## Limitations Summary
+
+- The DNS abstraction is only created when the deployment is multizone
+- `netapp_service_level` must be `FLEX` for zone-redundant storage pools
+- The feature provides a stable endpoint, but application failover still requires operational recovery steps
+- If you use single-zone node placement, the DNS abstraction is not created
+
+## Backward Compatibility
+
+Existing single-zone deployments continue to work with the current defaults.
+
+- `regional` defaults to `false`
+- `default_nodepool_locations` defaults to an empty string
+- `nodepools_locations` defaults to an empty string
+- `enable_netapp_dns` defaults to `false`
+
+## Default Values
+
+### GKE Defaults (Single-Zone Behavior)
+
+```hcl
+regional = false
+default_nodepool_locations = ""
+nodepools_locations = ""
+```
+
+### NetApp Defaults (DNS Disabled)
+
+```hcl
+storage_type         = "standard"
+netapp_service_level = "PREMIUM"
+enable_netapp_dns    = false
+netapp_dns_zone_name = "netapp-private.internal"
+netapp_dns_hostname  = "netapp-volume"
+netapp_dns_record_ttl = 300
+```
+
+## Cost Considerations
+
+Enabling multizone GKE and NetApp DNS abstraction can increase infrastructure cost:
+
+| Area | Cost Impact | Notes |
+| :--- | :--- | :--- |
+| Regional GKE control plane | Low to moderate | Depends on cluster size and node placement |
+| Multi-zone node pools | Moderate | More nodes may be distributed across zones |
+| NetApp `FLEX` storage | Higher than single-zone setups | Required for zone-redundant NetApp pools |
+| Cloud DNS | Low | Small incremental cost for zone and A record |
+
+## Recommended Architecture
+
+For production multizone deployments, use both GKE multizone placement and NetApp DNS abstraction together:
+
+```text
+Zone A                         Zone B
+├─ GKE nodes                   ├─ GKE nodes
+├─ Application pods            ├─ Application pods
+├─ NetApp primary endpoint     ├─ NetApp DNS-targeted failover
+└─ Regional control plane       └─ Shared storage endpoint
+```
+
+When the NetApp DNS abstraction is enabled, application workloads reference a stable hostname via `rwx_filestore_endpoint` instead of a zone-specific IP.
+
+## Best Practices for GCP Multi-Zone
+
+1. Use `regional = true` when deploying across multiple zones.
+2. Set `default_nodepool_locations` with at least two zones.
+3. Use `storage_type = "ha"` only when you need Google NetApp Volumes.
+4. Set `netapp_service_level = "FLEX"` for zone-redundant storage pools.
+5. Enable `enable_netapp_dns = true` only for multizone deployments.
+6. Keep `netapp_dns_record_ttl` at a value that balances failover speed and DNS stability.
+
+## References
+
+### Related GCP Documentation
+
+- [CONFIG-VARS.md](../CONFIG-VARS.md) - All configuration variables
+- [APIServices.md](APIServices.md) - Required GCP APIs
+- [TerraformGCPAuthentication.md](TerraformGCPAuthentication.md) - Required IAM roles
+
+### Related Configuration Files
+
+- `examples/sample-input-multizone.tfvars` - Example multizone configuration
+- `modules/google_netapp/main.tf` - DNS zone and record creation
+- `modules/google_netapp/outputs.tf` - NetApp endpoint outputs
+- `vms.tf` - Shared storage endpoint selection

--- a/docs/user/TerraformGCPAuthentication.md
+++ b/docs/user/TerraformGCPAuthentication.md
@@ -39,7 +39,7 @@ The Service Account will need the following [IAM roles](https://cloud.google.com
 | `roles/container.admin` | Kubernetes Engine Admin | Cluster creation |
 | `roles/container.clusterAdmin` | Kubernetes Engine Cluster Admin | Terraform Kubernetes Engine Module |
 | `roles/container.developer` | Kubernetes Engine Developer | Cluster creation |
-| `roles/file.editor` | Cloud Filestore Editor | Needed for [`storage_type=="ha" && storage_type_backend = "filestore"`](../CONFIG-VARS.md#storage) |
+| `roles/file.editor` | Cloud Filestore Editor | Needed for [`storage_type=="standard" && storage_type_backend=="filestore"`](../CONFIG-VARS.md#storage) |
 | `roles/netapp.admin` | NetApp Admin | Needed for [`storage_type=="ha" && storage_type_backend = "netapp"`](../CONFIG-VARS.md#storage) |
 | `roles/netapp.viewer` | NetApp Viewer | Needed for [`storage_type=="ha" && storage_type_backend = "netapp"`](../CONFIG-VARS.md#storage) |
 | `roles/dns.admin` | DNS Administrator | Needed when [`enable_netapp_dns=true`](../CONFIG-VARS.md#for-storage_typeha-with-google-netapp-volumes) for NetApp Cross-Zone Replication DNS abstraction |

--- a/docs/user/TerraformGCPAuthentication.md
+++ b/docs/user/TerraformGCPAuthentication.md
@@ -42,6 +42,7 @@ The Service Account will need the following [IAM roles](https://cloud.google.com
 | `roles/file.editor` | Cloud Filestore Editor | Needed for [`storage_type=="ha" && storage_type_backend = "filestore"`](../CONFIG-VARS.md#storage) |
 | `roles/netapp.admin` | NetApp Admin | Needed for [`storage_type=="ha" && storage_type_backend = "netapp"`](../CONFIG-VARS.md#storage) |
 | `roles/netapp.viewer` | NetApp Viewer | Needed for [`storage_type=="ha" && storage_type_backend = "netapp"`](../CONFIG-VARS.md#storage) |
+| `roles/dns.admin` | DNS Administrator | Needed when [`enable_netapp_dns=true`](../CONFIG-VARS.md#for-storage_typeha-with-google-netapp-volumes) for NetApp Cross-Zone Replication DNS abstraction |
 | `roles/iam.serviceAccountAdmin` | Service Account Admin | Terraform Kubernetes Engine Module |
 | `roles/iam.serviceAccountUser` | Service Account User | Terraform Kubernetes Engine Module |
 | `roles/resourcemanager.projectIamAdmin` | Project IAM Admin | Terraform Kubernetes Engine Module |
@@ -63,6 +64,7 @@ gcloud projects add-iam-policy-binding $PROJECT --member serviceAccount:${SA_NAM
 gcloud projects add-iam-policy-binding $PROJECT --member serviceAccount:${SA_NAME}@${PROJECT}.iam.gserviceaccount.com --role roles/file.editor
 gcloud projects add-iam-policy-binding $PROJECT --member serviceAccount:${SA_NAME}@${PROJECT}.iam.gserviceaccount.com --role roles/netapp.admin
 gcloud projects add-iam-policy-binding $PROJECT --member serviceAccount:${SA_NAME}@${PROJECT}.iam.gserviceaccount.com --role roles/netapp.viewer
+gcloud projects add-iam-policy-binding $PROJECT --member serviceAccount:${SA_NAME}@${PROJECT}.iam.gserviceaccount.com --role roles/dns.admin
 gcloud projects add-iam-policy-binding $PROJECT --member serviceAccount:${SA_NAME}@${PROJECT}.iam.gserviceaccount.com --role roles/iam.serviceAccountAdmin
 gcloud projects add-iam-policy-binding $PROJECT --member serviceAccount:${SA_NAME}@${PROJECT}.iam.gserviceaccount.com --role roles/iam.serviceAccountUser
 gcloud projects add-iam-policy-binding $PROJECT --member serviceAccount:${SA_NAME}@${PROJECT}.iam.gserviceaccount.com --role roles/resourcemanager.projectIamAdmin

--- a/examples/sample-input-ha.tfvars
+++ b/examples/sample-input-ha.tfvars
@@ -100,4 +100,4 @@ jump_vm_admin         = "jumpuser"
 #            For HA / Multi-Zone deployments, storage_type = "ha" provisions Google NetApp Volumes.
 #            Do NOT use storage_type = "ha" expecting Google Filestore as an HA backend.
 storage_type = "ha"
-# storage_type_backend is no longer required. storage_type = "ha" always provisions Google NetApp Volumes.
+storage_type_backend = "netapp" # Required when storage_type = "ha"

--- a/examples/sample-input-multizone.tfvars
+++ b/examples/sample-input-multizone.tfvars
@@ -62,7 +62,7 @@ node_pools = {
     "local_ssd_count"   = 1
     "accelerator_count" = 0
     "accelerator_type"  = ""
-    # "node_locations" = "us-east1-b"  # Optional: single zone for compute (sas-compute-server does not support multi-zone)
+    # "node_locations" = "us-east1-b"  # Optional: override per-nodepool zone locations
   },
   stateless = {
     "vm_type"      = "n2-highmem-4"
@@ -108,6 +108,18 @@ jump_vm_admin         = "jumpuser"
 #            for Multi-Zone GKE deployments.
 storage_type = "ha"
 # storage_type_backend is no longer required. storage_type = "ha" always provisions Google NetApp Volumes.
+
+# Google NetApp Volumes Configuration
+netapp_service_level = "FLEX"     # Required for zone-redundant storage; valid values: PREMIUM, EXTREME, STANDARD, FLEX
+netapp_capacity_gib  = 2048       # Storage pool capacity in GiB (minimum 2048)
+netapp_protocols     = ["NFSV3"]  # Volume protocols; currently only NFSV3 is supported by SAS Viya
+
+# DNS Abstraction for NetApp Cross-Zone Replication (CZR) Endpoint
+# When enabled, creates a Private DNS zone with an A record pointing to the NetApp volume endpoint.
+# This allows for DNS-based failover in zone-redundant deployments.
+# Only applicable when storage_type="ha" AND multi-zone deployment is detected.
+netapp_dns_zone_name = "netapp.internal" # DNS zone name for NetApp endpoint (e.g., "netapp.internal")
+netapp_dns_record_ttl = 300              # TTL in seconds for DNS A record (default: 300)
 
 # GKE cluster control plane configuration
 regional = true # e.g., true for regional (multi-zone) control plane, false for zonal

--- a/examples/sample-input-multizone.tfvars
+++ b/examples/sample-input-multizone.tfvars
@@ -118,6 +118,7 @@ netapp_protocols     = ["NFSV3"]  # Volume protocols; currently only NFSV3 is su
 # When enabled, creates a Private DNS zone with an A record pointing to the NetApp volume endpoint.
 # This allows for DNS-based failover in zone-redundant deployments.
 # Only applicable when storage_type="ha" AND multi-zone deployment is detected.
+enable_netapp_dns    = true             # Enable Private DNS zone and A record for CZR endpoint
 netapp_dns_zone_name = "netapp.internal" # DNS zone name for NetApp endpoint (e.g., "netapp.internal")
 netapp_dns_record_ttl = 300              # TTL in seconds for DNS A record (default: 300)
 

--- a/examples/sample-input-multizone.tfvars
+++ b/examples/sample-input-multizone.tfvars
@@ -107,7 +107,7 @@ jump_vm_admin         = "jumpuser"
 #            Google NetApp Volumes is the only supported zone-redundant RWX storage backend
 #            for Multi-Zone GKE deployments.
 storage_type = "ha"
-# storage_type_backend is no longer required. storage_type = "ha" always provisions Google NetApp Volumes.
+storage_type_backend = "netapp" # Required when storage_type = "ha"
 
 # Google NetApp Volumes Configuration
 netapp_service_level = "FLEX"     # Required for zone-redundant storage; valid values: PREMIUM, EXTREME, STANDARD, FLEX

--- a/examples/sample-input-singlestore.tfvars
+++ b/examples/sample-input-singlestore.tfvars
@@ -114,4 +114,4 @@ jump_vm_admin         = "jumpuser"
 #            For HA / Multi-Zone deployments, storage_type = "ha" provisions Google NetApp Volumes.
 #            Do NOT use storage_type = "ha" expecting Google Filestore as an HA backend.
 storage_type = "ha"
-# storage_type_backend is no longer required. storage_type = "ha" always provisions Google NetApp Volumes.
+storage_type_backend = "netapp" # Required when storage_type = "ha"

--- a/locals.tf
+++ b/locals.tf
@@ -26,12 +26,12 @@ locals {
   )
 
   # Storage
-  # Updated: storage_type = "ha" always maps to "netapp" (zone-redundant, required for Multi-Zone).
-  # storage_type = "standard" maps to "filestore" (zonal, single-zone only).
+  # storage_type = "standard" defaults to "nfs" VM. Optional override: "filestore".
+  # storage_type = "ha" always maps to "netapp" (zone-redundant, required for Multi-Zone).
   # NOTE: Filestore is ZONAL and does NOT provide zone-redundant storage.
   #       For Multi-Zone HA deployments, always use storage_type = "ha" (NetApp Volumes).
   storage_type_backend = (var.storage_type == "none" ? "none"
-    : var.storage_type == "standard" ? "nfs"
+    : var.storage_type == "standard" ? (lower(var.storage_type_backend) == "filestore" ? "filestore" : "nfs")
   : var.storage_type == "ha" ? "netapp" : "none")
 
   # Kubernetes
@@ -63,11 +63,14 @@ locals {
       # 2. Fall back to global nodepools_locations if set
       # 3. Fall back to single local.zone
       node_locations = (
-        settings.node_locations != null && settings.node_locations != ""
-        ? settings.node_locations
-        : (var.nodepools_locations != "" && var.nodepools_locations != null
-          ? var.nodepools_locations
-          : local.zone
+        var.storage_type != "ha"
+        ? local.zone
+        : (settings.node_locations != null && settings.node_locations != ""
+          ? settings.node_locations
+          : (var.nodepools_locations != "" && var.nodepools_locations != null
+            ? var.nodepools_locations
+            : local.zone
+          )
         )
       )
     }
@@ -85,7 +88,7 @@ locals {
       "accelerator_count"  = 0
       "accelerator_type"   = ""
       "initial_node_count" = var.default_nodepool_min_nodes
-      "node_locations"     = var.default_nodepool_locations != "" && var.default_nodepool_locations != null ? var.default_nodepool_locations : local.zone
+      "node_locations"     = var.storage_type != "ha" ? local.zone : (var.default_nodepool_locations != "" && var.default_nodepool_locations != null ? var.default_nodepool_locations : local.zone)
     }
   })
 

--- a/main.tf
+++ b/main.tf
@@ -330,5 +330,10 @@ module "google_netapp" {
   default_nodepool_locations = var.default_nodepool_locations
   depends_on         = [ module.gke ]
 
+  # DNS abstraction for zone-redundant endpoint
+  enable_netapp_dns    = var.enable_netapp_dns
+  netapp_dns_zone_name = var.netapp_dns_zone_name
+  netapp_dns_hostname  = var.netapp_dns_hostname
+
   community_netapp_networking_components_enabled = var.community_netapp_networking_components_enabled
 }

--- a/main.tf
+++ b/main.tf
@@ -321,6 +321,7 @@ module "google_netapp" {
   prefix             = var.prefix
   region             = local.region
   network            = module.vpc.network_name
+  network_self_link  = module.vpc.network_self_link
   netapp_subnet_cidr = var.netapp_subnet_cidr
   service_level      = var.netapp_service_level
   capacity_gib       = var.netapp_capacity_gib
@@ -331,9 +332,10 @@ module "google_netapp" {
   depends_on         = [ module.gke ]
 
   # DNS abstraction for zone-redundant endpoint
-  enable_netapp_dns    = var.enable_netapp_dns
-  netapp_dns_zone_name = var.netapp_dns_zone_name
-  netapp_dns_hostname  = var.netapp_dns_hostname
+  enable_netapp_dns     = var.enable_netapp_dns
+  netapp_dns_zone_name  = var.netapp_dns_zone_name
+  netapp_dns_hostname   = var.netapp_dns_hostname
+  netapp_dns_record_ttl = var.netapp_dns_record_ttl
 
   community_netapp_networking_components_enabled = var.community_netapp_networking_components_enabled
 }

--- a/modules/google_netapp/main.tf
+++ b/modules/google_netapp/main.tf
@@ -78,3 +78,29 @@ resource "google_netapp_volume" "netapp-nfs-volume" {
     google_service_networking_connection.default
   ]
 }
+
+# Private DNS zone for zone-redundant NetApp endpoint
+resource "google_dns_managed_zone" "netapp_private_zone" {
+  count       = var.enable_netapp_dns && local.is_multizone ? 1 : 0
+  name        = "${var.prefix}-netapp-dns-zone"
+  dns_name    = "${var.netapp_dns_zone_name}."
+  description = "Private DNS zone for zone-redundant NetApp volume endpoint"
+  visibility  = "private"
+
+  private_visibility_config {
+    networks {
+      network_url = var.network
+    }
+  }
+}
+
+# DNS A record pointing to the NetApp volume IP
+resource "google_dns_record_set" "netapp_a_record" {
+  count        = var.enable_netapp_dns && local.is_multizone ? 1 : 0
+  name         = "${var.netapp_dns_hostname}.${var.netapp_dns_zone_name}."
+  type         = "A"
+  ttl          = 300
+  managed_zone = google_dns_managed_zone.netapp_private_zone[0].name
+
+  rrdatas = [split(":", google_netapp_volume.netapp-nfs-volume.mount_options[0].export_full)[0]]
+}

--- a/modules/google_netapp/main.tf
+++ b/modules/google_netapp/main.tf
@@ -89,9 +89,11 @@ resource "google_dns_managed_zone" "netapp_private_zone" {
 
   private_visibility_config {
     networks {
-      network_url = var.network
+      network_url = var.network_self_link
     }
   }
+
+  depends_on = [google_service_networking_connection.default]
 }
 
 # DNS A record pointing to the NetApp volume IP

--- a/modules/google_netapp/main.tf
+++ b/modules/google_netapp/main.tf
@@ -101,7 +101,7 @@ resource "google_dns_record_set" "netapp_a_record" {
   count        = var.enable_netapp_dns && local.is_multizone ? 1 : 0
   name         = "${var.netapp_dns_hostname}.${var.netapp_dns_zone_name}."
   type         = "A"
-  ttl          = 300
+  ttl          = var.netapp_dns_record_ttl
   managed_zone = google_dns_managed_zone.netapp_private_zone[0].name
 
   rrdatas = [split(":", google_netapp_volume.netapp-nfs-volume.mount_options[0].export_full)[0]]

--- a/modules/google_netapp/outputs.tf
+++ b/modules/google_netapp/outputs.tf
@@ -5,3 +5,18 @@ output "mountpath" {
 output "export_ip" {
   value = split(":", google_netapp_volume.netapp-nfs-volume.mount_options[0].export_full)[0]
 }
+
+output "dns_hostname" {
+  description = "DNS hostname for the NetApp volume endpoint (when DNS is enabled)"
+  value       = var.enable_netapp_dns && local.is_multizone ? "${var.netapp_dns_hostname}.${var.netapp_dns_zone_name}" : null
+}
+
+output "dns_zone_name" {
+  description = "Private DNS zone name for NetApp endpoint"
+  value       = var.enable_netapp_dns && local.is_multizone ? var.netapp_dns_zone_name : null
+}
+
+output "endpoint" {
+  description = "NetApp volume endpoint - DNS hostname if enabled, otherwise IP address"
+  value       = var.enable_netapp_dns && local.is_multizone ? "${var.netapp_dns_hostname}.${var.netapp_dns_zone_name}" : split(":", google_netapp_volume.netapp-nfs-volume.mount_options[0].export_full)[0]
+}

--- a/modules/google_netapp/variables.tf
+++ b/modules/google_netapp/variables.tf
@@ -40,6 +40,10 @@ variable "network" {
   type        = string
 }
 
+variable "network_self_link" {
+  description = "Full self-link URL of the VPC network for DNS private visibility config"
+  type        = string
+}
 
 variable "allowed_clients" {
   description = "CIDR blocks allowed to mount nfs exports"

--- a/modules/google_netapp/variables.tf
+++ b/modules/google_netapp/variables.tf
@@ -58,9 +58,28 @@ variable "default_nodepool_locations" {
   type        = string
 }
 
+
+}
+
 # Community Contribution
 variable "community_netapp_networking_components_enabled" {
   description = "Community Contribution. Enable/Disable the deployment of Networking components for Netapp resources. Enabled by default."
   type        = bool
   default     = true
 }
+variable "enable_netapp_dns" {
+  description = "Enable Private DNS zone and A record for zone-redundant NetApp endpoint. Only applicable for multi-zone HA deployments with FLEX service level."
+  type        = bool
+  default     = false
+}
+
+variable "netapp_dns_zone_name" {
+  description = "Name for the Private DNS zone for NetApp endpoint. Only used when enable_netapp_dns=true."
+  type        = string
+  default     = "netapp-private.internal"
+}
+
+variable "netapp_dns_hostname" {
+  description = "DNS hostname for the NetApp volume endpoint. Only used when enable_netapp_dns=true."
+  type        = string
+  default     = "netapp-volume"

--- a/modules/google_netapp/variables.tf
+++ b/modules/google_netapp/variables.tf
@@ -58,9 +58,6 @@ variable "default_nodepool_locations" {
   type        = string
 }
 
-
-}
-
 # Community Contribution
 variable "community_netapp_networking_components_enabled" {
   description = "Community Contribution. Enable/Disable the deployment of Networking components for Netapp resources. Enabled by default."
@@ -83,3 +80,10 @@ variable "netapp_dns_hostname" {
   description = "DNS hostname for the NetApp volume endpoint. Only used when enable_netapp_dns=true."
   type        = string
   default     = "netapp-volume"
+}
+
+variable "netapp_dns_record_ttl" {
+  description = "TTL in seconds for the DNS A record. Only used when enable_netapp_dns=true."
+  type        = number
+  default     = 300
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -24,11 +24,11 @@ output "postgres_servers" {
 }
 
 output "rwx_filestore_endpoint" {
-  description = "Shared Storage private IP"
+  description = "Shared Storage endpoint (DNS hostname when enable_netapp_dns=true for HA NetApp, otherwise IP address)"
   value = (var.storage_type == "none"
     ? null
     : var.storage_type == "ha" && local.storage_type_backend == "filestore" ? google_filestore_instance.rwx[0].networks[0].ip_addresses[0]
-    : var.storage_type == "ha" && local.storage_type_backend == "netapp" ? module.google_netapp[0].export_ip : module.nfs_server[0].private_ip
+    : var.storage_type == "ha" && local.storage_type_backend == "netapp" ? module.google_netapp[0].endpoint : module.nfs_server[0].private_ip
   )
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -27,7 +27,7 @@ output "rwx_filestore_endpoint" {
   description = "Shared Storage endpoint (DNS hostname when enable_netapp_dns=true for HA NetApp, otherwise IP address)"
   value = (var.storage_type == "none"
     ? null
-    : var.storage_type == "ha" && local.storage_type_backend == "filestore" ? google_filestore_instance.rwx[0].networks[0].ip_addresses[0]
+    : var.storage_type == "standard" && local.storage_type_backend == "filestore" ? google_filestore_instance.rwx[0].networks[0].ip_addresses[0]
     : var.storage_type == "ha" && local.storage_type_backend == "netapp" ? module.google_netapp[0].endpoint : module.nfs_server[0].private_ip
   )
 }
@@ -36,7 +36,7 @@ output "rwx_filestore_path" {
   description = "Shared Storage mount path"
   value = (var.storage_type == "none"
     ? null
-    : var.storage_type == "ha" && local.storage_type_backend == "filestore" ? "/${google_filestore_instance.rwx[0].file_shares[0].name}"
+    : var.storage_type == "standard" && local.storage_type_backend == "filestore" ? "/${google_filestore_instance.rwx[0].file_shares[0].name}"
     : var.storage_type == "ha" && local.storage_type_backend == "netapp" ? module.google_netapp[0].mountpath : "/export"
   )
 }
@@ -81,15 +81,15 @@ output "jump_admin_username" {
 
 # NFS server
 output "nfs_private_ip" {
-  value = var.storage_type == "standard" ? module.nfs_server[0].private_ip : null
+  value = var.storage_type == "standard" && local.storage_type_backend == "nfs" ? module.nfs_server[0].private_ip : null
 }
 
 output "nfs_public_ip" {
-  value = var.storage_type == "standard" ? module.nfs_server[0].public_ip : null
+  value = var.storage_type == "standard" && local.storage_type_backend == "nfs" ? module.nfs_server[0].public_ip : null
 }
 
 output "nfs_admin_username" {
-  value = var.storage_type == "standard" ? module.nfs_server[0].admin_username : null
+  value = var.storage_type == "standard" && local.storage_type_backend == "nfs" ? module.nfs_server[0].admin_username : null
 }
 
 # Container registry
@@ -110,10 +110,10 @@ output "gke_pod_subnet_cidr" {
 }
 
 output "storage_type_backend" {
-  value       = var.storage_type_backend
-  description = "If storage_type=standard the default is nfs. If storage_type=ha the default is filestore"
+  value       = local.storage_type_backend
+  description = "Effective storage backend (standard defaults to nfs unless filestore is selected; ha uses netapp)"
 }
 
 output "netapp_volume_path" {
-  value       = var.storage_type_backend == "netapp" ? var.netapp_volume_path : "export"
+  value       = local.storage_type_backend == "netapp" ? var.netapp_volume_path : "export"
 }

--- a/test/nondefaultplan/netapp_test.go
+++ b/test/nondefaultplan/netapp_test.go
@@ -20,6 +20,8 @@ func TestPlanNetApp(t *testing.T) {
 	variables["prefix"] = "net-app"
 	variables["storage_type"] = "ha"
 	variables["storage_type_backend"] = "netapp"
+	variables["default_nodepool_locations"] = "us-east1-b,us-east1-c"
+	variables["nodepools_locations"] = "us-east1-b,us-east1-c"
 
 	tests := map[string]helpers.TestCase{
 		"poolExists": {

--- a/variables.tf
+++ b/variables.tf
@@ -526,6 +526,17 @@ variable "netapp_dns_hostname" {
   }
 }
 
+variable "netapp_dns_record_ttl" {
+  description = "TTL in seconds for the DNS A record. Only used when enable_netapp_dns=true."
+  type        = number
+  default     = 300
+
+  validation {
+    condition     = var.netapp_dns_record_ttl >= 60 && var.netapp_dns_record_ttl <= 86400
+    error_message = "netapp_dns_record_ttl must be between 60 and 86400 seconds (1 minute to 1 day)."
+  }
+}
+
 # GKE Monitoring
 variable "create_gke_monitoring_service" {
   description = "Enable GKE metrics from pods in the cluster to the Google Cloud Monitoring API."

--- a/variables.tf
+++ b/variables.tf
@@ -24,6 +24,11 @@ variable "regional" {
   description = "Should the GKE cluster have a regional or zonal control plane"
   type        = bool
   default     = true
+
+  validation {
+    condition     = var.storage_type != "ha" || var.regional
+    error_message = "ERROR: regional must be true when storage_type='ha'."
+  }
 }
 
 variable "service_account_keyfile" {
@@ -184,8 +189,8 @@ variable "storage_type" {
           For Multi-Zone GKE deployments, always use storage_type = "ha" (NetApp Volumes).
     NOTE: storage_type="none" is for internal use only.
   EOF
-  type    = string
-  default = "standard"
+  type        = string
+  default     = "standard"
   validation {
     condition     = contains(["standard", "ha", "none"], lower(var.storage_type))
     error_message = "ERROR: Supported values for `storage_type` are - standard, ha."
@@ -195,17 +200,30 @@ variable "storage_type" {
 variable "storage_type_backend" {
   description = <<-EOF
     The storage backend used for the chosen storage type.
-    - storage_type = "standard" : backend is always "nfs" (Google Filestore - ZONAL).
+    - storage_type = "standard" : backend defaults to "nfs" VM; optional "filestore" is supported.
     - storage_type = "ha"        : backend is always "netapp" (Google NetApp Volumes - Zone-Redundant).
     NOTE: Filestore is no longer a valid backend for storage_type = "ha".
           For Multi-Zone HA deployments, NetApp Volumes is the only supported zone-redundant RWX backend.
   EOF
-  type    = string
-  default = "nfs"
+  type        = string
+  default     = "nfs"
 
   validation {
     condition     = contains(["nfs", "filestore", "netapp", "none"], lower(var.storage_type_backend))
     error_message = "ERROR: Supported values for `storage_type_backend` are nfs, filestore, netapp or none."
+  }
+
+  validation {
+    condition = (
+      var.storage_type == "standard"
+      ? contains(["nfs", "filestore"], lower(var.storage_type_backend))
+      : var.storage_type == "ha"
+      ? lower(var.storage_type_backend) == "netapp"
+      : var.storage_type == "none"
+      ? lower(var.storage_type_backend) == "none"
+      : true
+    )
+    error_message = "ERROR: Invalid storage_type/storage_type_backend combination. Use standard with nfs or filestore, ha with netapp, and none with none."
   }
 }
 
@@ -263,6 +281,17 @@ variable "default_nodepool_locations" {
   description = "GCP zone(s) where the default nodepool will allocate nodes in. Comma separated list."
   type        = string
   default     = ""
+
+  validation {
+    condition = (
+      var.storage_type == "ha"
+      ? length([for zone in split(",", var.default_nodepool_locations) : trimspace(zone) if trimspace(zone) != ""]) >= 2
+      : var.storage_type == "standard"
+      ? length([for zone in split(",", var.default_nodepool_locations) : trimspace(zone) if trimspace(zone) != ""]) <= 1
+      : true
+    )
+    error_message = "ERROR: default_nodepool_locations must contain 2+ zones when storage_type='ha' and at most 1 zone when storage_type='standard'."
+  }
 }
 
 variable "node_pools" {
@@ -281,7 +310,7 @@ variable "node_pools" {
     # If set, overrides nodepools_locations for this specific nodepool.
     # e.g., "us-east1-b,us-east1-c" for multi-zone or "us-east1-b" for single-zone.
     # Equivalent to Azure availability_zones per nodepool.
-    node_locations    = optional(string, "")
+    node_locations = optional(string, "")
   }))
   default = {
     cas = {
@@ -351,6 +380,17 @@ variable "nodepools_locations" {
   description = "Global fallback GCP zone(s) for all additional node pools that do not specify their own node_locations. Comma separated list. Per-nodepool zones can be set via node_pools.<name>.node_locations."
   type        = string
   default     = ""
+
+  validation {
+    condition = (
+      var.storage_type == "ha"
+      ? length([for zone in split(",", var.nodepools_locations) : trimspace(zone) if trimspace(zone) != ""]) >= 2
+      : var.storage_type == "standard"
+      ? length([for zone in split(",", var.nodepools_locations) : trimspace(zone) if trimspace(zone) != ""]) <= 1
+      : true
+    )
+    error_message = "ERROR: nodepools_locations must contain 2+ zones when storage_type='ha' and at most 1 zone when storage_type='standard'."
+  }
 }
 
 variable "enable_cluster_autoscaling" {
@@ -406,7 +446,7 @@ variable "postgres_servers" {
   description = "Map of PostgreSQL server objects"
   type        = any
   default     = null
- 
+
   # Checking for user provided "default" server
   validation {
     condition     = var.postgres_servers != null ? length(var.postgres_servers) != 0 ? contains(keys(var.postgres_servers), "default") : false : true
@@ -431,8 +471,8 @@ variable "postgres_servers" {
       for k, v in var.postgres_servers : (
         # If the object is empty, use default values
         length(keys(v)) == 0 ? true : (
-          can(try(v.server_version, null)) && 
-          can(try(v.edition, null)) && 
+          can(try(v.server_version, null)) &&
+          can(try(v.edition, null)) &&
           can(try(v.machine_type, null)) && (
             (tonumber(try(v.server_version, "15")) >= 16 && try(v.edition, "ENTERPRISE") == "ENTERPRISE_PLUS" && can(regex("^db-perf-optimized-N-", try(v.machine_type, "")))) ||
             (tonumber(try(v.server_version, "15")) < 16 && try(v.edition, "ENTERPRISE") == "ENTERPRISE" && can(regex("^db-custom-", try(v.machine_type, ""))))

--- a/variables.tf
+++ b/variables.tf
@@ -503,6 +503,29 @@ variable "netapp_volume_path" {
   default     = "export"
 }
 
+variable "enable_netapp_dns" {
+  description = "Enable Private DNS zone and A record for zone-redundant NetApp endpoint. Requires storage_type='ha' and multi-zone deployment (default_nodepool_locations with multiple zones). Provides stable DNS hostname for failover scenarios."
+  type        = bool
+  default     = false
+}
+
+variable "netapp_dns_zone_name" {
+  description = "Name for the Private DNS zone for NetApp endpoint. Only used when enable_netapp_dns=true."
+  type        = string
+  default     = "netapp-private.internal"
+}
+
+variable "netapp_dns_hostname" {
+  description = "DNS hostname for the NetApp volume endpoint. Only used when enable_netapp_dns=true."
+  type        = string
+  default     = "netapp-volume"
+
+  validation {
+    condition     = can(regex("^[a-z0-9]([-a-z0-9]*[a-z0-9])?$", var.netapp_dns_hostname))
+    error_message = "netapp_dns_hostname must be a valid DNS hostname (lowercase alphanumeric and hyphens only, cannot start or end with hyphen)."
+  }
+}
+
 # GKE Monitoring
 variable "create_gke_monitoring_service" {
   description = "Enable GKE metrics from pods in the cluster to the Google Cloud Monitoring API."

--- a/vms.tf
+++ b/vms.tf
@@ -4,12 +4,12 @@
 locals {
   rwx_filestore_endpoint = (var.storage_type == "none"
     ? ""
-    : var.storage_type == "ha" && local.storage_type_backend == "filestore" ? google_filestore_instance.rwx[0].networks[0].ip_addresses[0]
+    : var.storage_type == "standard" && local.storage_type_backend == "filestore" ? google_filestore_instance.rwx[0].networks[0].ip_addresses[0]
     : var.storage_type == "ha" && local.storage_type_backend == "netapp" ? module.google_netapp[0].endpoint : module.nfs_server[0].private_ip
   )
   rwx_filestore_path = (var.storage_type == "none"
     ? ""
-    : var.storage_type == "ha" && local.storage_type_backend == "filestore" ? "/${google_filestore_instance.rwx[0].file_shares[0].name}"
+    : var.storage_type == "standard" && local.storage_type_backend == "filestore" ? "/${google_filestore_instance.rwx[0].file_shares[0].name}"
     : var.storage_type == "ha" && local.storage_type_backend == "netapp" ? module.google_netapp[0].mountpath : "/export"
   )
   protocol_version = var.storage_type == "ha" && local.storage_type_backend == "netapp" ? split("V", var.netapp_protocols[0])[1] == "4" ? "4.1" : "3" : "3"

--- a/vms.tf
+++ b/vms.tf
@@ -5,7 +5,7 @@ locals {
   rwx_filestore_endpoint = (var.storage_type == "none"
     ? ""
     : var.storage_type == "ha" && local.storage_type_backend == "filestore" ? google_filestore_instance.rwx[0].networks[0].ip_addresses[0]
-    : var.storage_type == "ha" && local.storage_type_backend == "netapp" ? module.google_netapp[0].export_ip : module.nfs_server[0].private_ip
+    : var.storage_type == "ha" && local.storage_type_backend == "netapp" ? module.google_netapp[0].endpoint : module.nfs_server[0].private_ip
   )
   rwx_filestore_path = (var.storage_type == "none"
     ? ""


### PR DESCRIPTION
## Summary

Adds Private DNS zone abstraction for Google NetApp Volumes zone-redundant 
(Cross-Zone Replication) deployments. When enabled, a GCP Private DNS zone 
and A record are created pointing to the NetApp volume IP, providing a stable 
DNS hostname for failover scenarios instead of a raw IP address.

## Changes

### New Variables (`variables.tf` / `modules/google_netapp/variables.tf`)
- `enable_netapp_dns` — Enable Private DNS zone and A record for CZR endpoint (default: `false`)
- `netapp_dns_zone_name` — Name of the Private DNS zone (default: `"netapp-private.internal"`)
- `netapp_dns_hostname` — DNS hostname for the NetApp volume (default: `"netapp-volume"`)
- `netapp_dns_record_ttl` — TTL in seconds for the DNS A record, range 60–86400 (default: `300`)

### Infrastructure (`modules/google_netapp/main.tf`)
- Added `google_dns_managed_zone` resource — creates a private DNS zone scoped to the VPC
- Added `google_dns_record_set` resource — creates an A record pointing to the NetApp volume IP
- Both resources are conditional: only created when `enable_netapp_dns=true` **and** a multi-zone deployment is detected
- Added `network_self_link` variable to support VPC-scoped DNS private visibility config